### PR TITLE
Plan lekcji z zastępstwami, wydarzenia z terminarza na kartach, opcja częstotliwości w UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,19 @@ Thumbs.db
 
 # Test credentials
 test_credentials.yaml
+# Pliki runtime generowane przez Home Assistant w srodowisku testowym
+config/.storage/
+config/.cloud/
+config/.HA_VERSION
+config/.ha_run.lock
+config/home-assistant*.db*
+config/home-assistant.log*
+config/blueprints/
+config/tts/
+config/deps/
+config/image/
+# Mushroom pobierany lokalnie do podgladu kart (663 KB, nie wersjonujemy)
+config/www/mushroom.js
+# Dashboard srodowiska testowego - generowany z kart w README i zawiera
+# entity_id z prawdziwym imieniem ucznia. Repo jest publiczne.
+config/ui-lovelace.yaml

--- a/README.md
+++ b/README.md
@@ -445,11 +445,13 @@ content: |-
 
 **Dzień znika, gdy skończy się jego ostatnia lekcja.** Po ostatniej lekcji dnia karta
 przechodzi na najbliższy kolejny dzień z zajęciami, a plan tygodnia przestaje pokazywać
-dni już zakończone. Tę samą zasadę stosuje atrybut `zmiany` — zastępstwo z lekcji,
+dni już zakończone — i **dobiera kolejny dzień w jego miejsce**, więc widać zawsze 5 dni
+lekcyjnych, a nie 4 po południu. Liczbę dni zmienisz stałą `DEFAULT_PLAN_DAYS`
+w `const.py`. Tę samą zasadę stosuje atrybut `zmiany` — zastępstwo z lekcji,
 która już się odbyła, nie jest raportowane.
 
-Atrybut `tydzien` (słownik `data → lekcje`) zawiera najbliższe 7 dni i jest **jedynym
-miejscem z listą lekcji** — recorder w Home Assistant odrzuca stan encji powyżej 16 KB
+Atrybut `tydzien` (słownik `data → lekcje`) zawiera **zawsze 5 najbliższych dni
+lekcyjnych** i jest **jedynym miejscem z listą lekcji** — recorder w Home Assistant odrzuca stan encji powyżej 16 KB
 atrybutów, więc lekcje nie są duplikowane. Dzień do wyświetlenia wskazują
 `biezacy_dzien_data` i `biezacy_dzien_nazwa`; karta pobiera lekcje przez
 `tydzien[biezacy_dzien_data]`. Czujnik przelicza to co minutę lokalnie, bez odpytywania

--- a/README.md
+++ b/README.md
@@ -641,13 +641,29 @@ Jeśli znajdziesz błąd:
    - Krokami do reprodukcji
    - Logami (usuń dane osobowe!)
 
-## 📄 Licencja
+## 📄 Licencja i komponenty zewnętrzne
 
-MIT License - patrz [LICENSE](LICENSE)
+Projekt jest udostępniany na licencji **MIT** — pełny tekst w pliku
+[LICENSE](LICENSE).
+
+Poniższe składniki **nie są dystrybuowane razem z tym repozytorium** — Home
+Assistant lub HACS pobierają je osobno. Wymieniamy je dla przejrzystości:
+
+| Komponent | Licencja | Autor | Sposób użycia |
+|-----------|----------|-------|----------------|
+| [librus-apix](https://github.com/poroknights/librus-apix) | MIT | Pascal Jodłowski | zależność `pip`, deklarowana w `manifest.json` |
+| [Mushroom Cards](https://github.com/piitaya/lovelace-mushroom) | Apache-2.0 | piitaya | opcjonalny dodatek frontendu, instalowany z HACS |
+| [Home Assistant](https://github.com/home-assistant/core) | Apache-2.0 | Nabu Casa i społeczność | środowisko uruchomieniowe integracji |
+
+Integracja komunikuje się z systemem **Librus Synergia**. Projekt nie jest
+powiązany z firmą Librus ani przez nią wspierany; nazwa użyta wyłącznie
+w celach identyfikacyjnych.
 
 ## 🤝 Wkład
 
-Pull requesty są mile widziane! Sprawdź [CONTRIBUTING.md](CONTRIBUTING.md)
+Pull requesty są mile widziane — zgłoś je przez
+[Issues](https://github.com/LukMaverick/LibrusSynergiaHA/issues) lub bezpośrednio
+jako PR.
 
 ### 🙏 Podziękowania
 
@@ -655,7 +671,7 @@ Specjalne podziękowania dla **KB** za wsparcie i pomoc w rozwoju projektu.
 
 ## 👨‍💻 Autor
 
-Stworzono na bazie biblioteki [librus-apix](https://github.com/RustySnek/librus-apix)
+Stworzono na bazie biblioteki [librus-apix](https://github.com/poroknights/librus-apix)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Lub ręcznie:
    - **Hasło**: Twoje hasło do Librus
 4. Kliknij **"Prześlij"**
 
+Po dodaniu integracji encje pojawią się w ciągu kilku sekund. Gotowy dashboard
+z planem lekcji wklejasz z pliku
+**[`examples/dashboard-plan-lekcji.yaml`](examples/dashboard-plan-lekcji.yaml)** —
+instrukcja krok po kroku w sekcji
+[Gotowy dashboard](#-gotowy-dashboard--plik-do-wklejenia).
+
 ## 🔧 Środowisko testowe
 
 Projekt zawiera local środowisko testowe z Docker:
@@ -185,32 +191,38 @@ Legenda ikon:
 - ⚫ szara = przeczytana
 - 📎 badge = ma załącznik
 
-### Złożenie kart w widok jednokolumnowy
+### 🚀 Gotowy dashboard — plik do wklejenia
 
-Trzy karty poniżej dobrze czytają się jedna pod drugą, w kolejności:
-**Nadchodzące wydarzenia → Plan lekcji → Plan tygodnia**.
+Nie musisz składać kart ręcznie. W repozytorium jest kompletny dashboard
+z planem lekcji:
 
-> **Uwaga:** `max_columns: 1` w widoku **nie zadziała**. Domyślny widok Lovelace
-> (masonry) ma puste `setConfig()` i liczy kolumny wyłącznie z szerokości ekranu,
-> ignorując konfigurację. Jedyny pewny sposób na jedną kolumnę to opakowanie
-> wszystkiego w pojedynczy `vertical-stack` — widok dostaje wtedy jedną kartę,
-> więc nie ma czego rozkładać na kolumny.
+**[`examples/dashboard-plan-lekcji.yaml`](examples/dashboard-plan-lekcji.yaml)**
 
-```yaml
-views:
-  - title: Plan lekcji
-    path: plan
-    icon: mdi:timetable
-    cards:
-      - type: vertical-stack
-        cards:
-          # 1. wklej tu zawartość karty "Nadchodzące wydarzenia"
-          # 2. potem kartę "Plan lekcji (Mushroom)"
-          # 3. na końcu kartę "Plan tygodnia"
-```
+Zawiera trzy karty jedna pod drugą: **Nadchodzące wydarzenia → Plan lekcji →
+Plan tygodnia**.
 
-Karty „Nadchodzące wydarzenia" i „Plan lekcji" same są `vertical-stack` —
-zagnieżdżanie stosów jest w Lovelace poprawne, wklejasz je bez zmian.
+#### Jak go wdrożyć
+
+1. **Zainstaluj Mushroom Cards** — HACS → Frontend → wyszukaj `Mushroom`.
+   Bez tego karty `custom:mushroom-*` pokażą *„Custom element doesn't exist"*.
+2. **Sprawdź nazwę swojej encji** — Narzędzia deweloperskie → Stany, wpisz
+   `plan_lekcji`. Encje biorą nazwę od imienia i nazwiska ucznia, np.
+   `sensor.librus_jan_kowalski_plan_lekcji`.
+3. **Utwórz dashboard** — Ustawienia → Dashboardy → Dodaj dashboard →
+   Nowy dashboard od zera.
+4. **Wklej konfigurację** — otwórz nowy dashboard, menu ⋮ → Edytuj, potem
+   ponownie ⋮ → **Edytor nieprzetworzonej konfiguracji**. Wklej całą zawartość
+   pliku.
+5. **Podmień encję** — zamień w całym wklejonym tekście
+   `sensor.librus_imie_nazwisko` na swoją nazwę z kroku 2. Zapisz.
+
+> **Uwaga o układzie:** karty są opakowane w jeden `vertical-stack`, żeby
+> wymusić jedną kolumnę. `max_columns: 1` **nie zadziała** — domyślny widok
+> Lovelace (masonry) ma puste `setConfig()` i liczy kolumny wyłącznie
+> z szerokości ekranu, ignorując konfigurację widoku.
+
+Pojedyncze karty opisane są niżej — przydadzą się, jeśli chcesz je wpleść
+we własny dashboard zamiast używać gotowego pliku.
 
 ### Karta nadchodzących wydarzeń (4 tygodnie)
 

--- a/README.md
+++ b/README.md
@@ -234,12 +234,13 @@ cards:
     title: 📚 Plan lekcji
     subtitle: >-
       {% set p = 'sensor.librus_imie_nazwisko_plan_lekcji' %}
-      {% set n = states(p) | int(0) %}
-      {% if n > 0 %}
-        Dziś {{ n }} lekcji · {{ state_attr(p, 'pierwsza_lekcja') }}–{{ state_attr(p, 'ostatnia_lekcja') }}
-      {% else %}
-        Dziś brak lekcji 🎉
-      {% endif %}
+      {% set dt = state_attr(p, 'biezacy_dzien_data') %}
+      {% set tydzien = state_attr(p, 'tydzien') %}
+      {% set d = tydzien[dt] if dt in tydzien else [] %}
+      {% if not d %}Brak nadchodzących lekcji 🎉{% else %}{% if
+      dt == now().strftime('%Y-%m-%d') %}Dziś{% else
+      %}{{ state_attr(p, 'biezacy_dzien_nazwa') }} {{ state_attr(p, 'biezacy_dzien_data')
+      }}{% endif %} · {{ d | count }} lekcji · {{ d[0].od }}–{{ d[-1].do }}{% endif %}
 
   - type: custom:mushroom-template-card
     primary: >-
@@ -254,14 +255,18 @@ cards:
       {% if states(s) in ['unknown', 'unavailable', 'None'] %}
         —
       {% elif state_attr(s, 'trwa_teraz') %}
-        Trwa do {{ state_attr(s, 'do') }} · sala {{ state_attr(s, 'nauczyciel_sala') }}
+        Trwa do {{ state_attr(s, 'do') }} · {{ state_attr(s, 'nauczyciel_sala') }}
+      {% elif state_attr(s, 'data') != now().strftime('%Y-%m-%d') %}
+        {{ state_attr(s, 'dzien_tygodnia') }} {{ state_attr(s, 'od') }} · {{ state_attr(s, 'nauczyciel_sala') }}
       {% else %}
         {{ state_attr(s, 'numer') }}. lekcja · {{ state_attr(s, 'od') }} ·
         za {{ state_attr(s, 'za_minut') }} min
       {% endif %}
     icon: >-
       {% set s = 'sensor.librus_imie_nazwisko_nastepna_lekcja' %}
-      {% if state_attr(s, 'trwa_teraz') %}mdi:school{% else %}mdi:clock-start{% endif %}
+      {% if state_attr(s, 'trwa_teraz') %}mdi:school
+      {% elif state_attr(s, 'data') != now().strftime('%Y-%m-%d') %}mdi:calendar-clock
+      {% else %}mdi:clock-start{% endif %}
     icon_color: >-
       {% set s = 'sensor.librus_imie_nazwisko_nastepna_lekcja' %}
       {% if state_attr(s, 'zastepstwo') %}orange
@@ -289,44 +294,90 @@ cards:
       icon_color: orange
 
   - type: markdown
-    content: >-
-      {% set lekcje = state_attr('sensor.librus_imie_nazwisko_plan_lekcji', 'dzisiaj') %}
-      {% if lekcje %} | # | Godzina | Przedmiot | Sala |
-       |---|---------|-----------|------|
-      {% for l in lekcje %} | {{ l.numer }} | {{ l.od }}–{{ l.do }} |
-      {% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo %}**{{ l.przedmiot }}** ⚠️{% else %}{{ l.przedmiot }}{% endif %}
-      | {{ l.nauczyciel_sala }} |
+    content: |-
+      {%- set p = 'sensor.librus_imie_nazwisko_plan_lekcji' %}
+      {%- set d = state_attr(p, 'biezacy_dzien_data') %}
+      {%- set tydzien = state_attr(p, 'tydzien') %}
+      {%- set lekcje = tydzien[d] if d in tydzien else [] %}
+      {%- set wd = state_attr(p, 'wydarzenia_dnia') %}
+      {%- set zd = state_attr(p, 'zadania_dnia') %}
+      {%- if lekcje %}
+      **{{ state_attr(p, 'biezacy_dzien_nazwa') }}, {{ d }}**
+      {%- for w in (wd[d] if d in wd else []) %}
 
-      {% endfor %} {% else %} Dziś nie ma lekcji. {% endif %}
+      📌 {{ w.przedmiot }}{% if w.godzina not in ['', 'unknown'] %} · {{ w.godzina }}{% endif %}
+      {%- endfor %}
+      {%- for z in (zd[d] if d in zd else []) %}
+
+      📚 {{ z.przedmiot }} · {{ z.kategoria }}
+      {%- endfor %}
+
+      | # | Godzina | Przedmiot | Sala |
+      |---|---------|-----------|------|
+      {%- for l in lekcje %}
+      | {{ l.numer }} | {{ l.od }}–{{ l.do }} | {% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo %}**{{ l.przedmiot }}** ⚠️{% else %}{{ l.przedmiot }}{% endif %}{% for w in l.wydarzenia %} 📝 {{ w.tytul }}{% endfor %}{% for z in l.zadania %} 📚 {{ z.kategoria }}{% endfor %} | {{ l.nauczyciel_sala }} |
+      {%- endfor %}
+      {%- else %}
+      Brak nadchodzących lekcji.
+      {%- endif %}
 ```
 
 Legenda:
 - 🟢 zielona ikona = lekcja trwa teraz
 - 🟠 pomarańczowa + 🔀 badge = zastępstwo
 - ~~przekreślony~~ przedmiot = lekcja odwołana
+- 📝 przy przedmiocie = wydarzenie z terminarza (sprawdzian, kartkówka)
+- 📚 przy przedmiocie = praca domowa na ten dzień
+- 📌 nad tabelą = wydarzenie całodniowe (wywiadówka, dzień wolny)
 
 ### Karta planu na cały tydzień
 
 ```yaml
 type: markdown
 title: 🗓️ Plan tygodnia
-content: >-
-  {% set tydzien = state_attr('sensor.librus_imie_nazwisko_plan_lekcji', 'tydzien') %}
-  {% if tydzien %} {% for data, lekcje in tydzien.items() %}
+content: |-
+  {%- set p = 'sensor.librus_imie_nazwisko_plan_lekcji' %}
+  {%- set tydzien = state_attr(p, 'tydzien') %}
+  {%- set wd = state_attr(p, 'wydarzenia_dnia') %}
+  {%- set zd = state_attr(p, 'zadania_dnia') %}
+  {%- if tydzien %}
+  {%- for data, lekcje in tydzien.items() %}
   **{{ lekcje[0].dzien_tygodnia }} {{ data }}**
+  {%- for w in (wd[data] if data in wd else []) %}
+
+  📌 {{ w.przedmiot }}{% if w.godzina not in ['', 'unknown'] %} · {{ w.godzina }}{% endif %}
+  {%- endfor %}
+  {%- for z in (zd[data] if data in zd else []) %}
+
+  📚 {{ z.przedmiot }} · {{ z.kategoria }}
+  {%- endfor %}
 
   | # | Godzina | Przedmiot | Sala |
-   |---|---------|-----------|------|
-  {% for l in lekcje %} | {{ l.numer }} | {{ l.od }}–{{ l.do }} |
-  {% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo %}**{{ l.przedmiot }}** ⚠️{% else %}{{ l.przedmiot }}{% endif %}
-  | {{ l.nauczyciel_sala }} |
-
+  |---|---------|-----------|------|
+  {%- for l in lekcje %}
+  | {{ l.numer }} | {{ l.od }}–{{ l.do }} | {% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo %}**{{ l.przedmiot }}** ⚠️{% else %}{{ l.przedmiot }}{% endif %}{% for w in l.wydarzenia %} 📝 {{ w.tytul }}{% endfor %}{% for z in l.zadania %} 📚 {{ z.kategoria }}{% endfor %} | {{ l.nauczyciel_sala }} |
+  {%- endfor %}
   {% endfor %}
-  {% endfor %} {% else %} Brak danych o planie lekcji. {% endif %}
+  {%- else %}
+  Brak danych o planie lekcji.
+  {%- endif %}
 ```
 
-Atrybut `tydzien` zawiera najbliższe 7 dni (integracja pobiera bieżący i następny tydzień,
-więc w piątek i w weekend widać już kolejny tydzień).
+**Dzień znika, gdy skończy się jego ostatnia lekcja.** Po ostatniej lekcji dnia karta
+przechodzi na najbliższy kolejny dzień z zajęciami, a plan tygodnia przestaje pokazywać
+dni już zakończone. Tę samą zasadę stosuje atrybut `zmiany` — zastępstwo z lekcji,
+która już się odbyła, nie jest raportowane.
+
+Atrybut `tydzien` (słownik `data → lekcje`) zawiera najbliższe 7 dni i jest **jedynym
+miejscem z listą lekcji** — recorder w Home Assistant odrzuca stan encji powyżej 16 KB
+atrybutów, więc lekcje nie są duplikowane. Dzień do wyświetlenia wskazują
+`biezacy_dzien_data` i `biezacy_dzien_nazwa`; karta pobiera lekcje przez
+`tydzien[biezacy_dzien_data]`. Czujnik przelicza to co minutę lokalnie, bez odpytywania
+Librusa.
+
+Każda lekcja ma pola `wydarzenia` (z terminarza) i `zadania` (prace domowe na ten dzień).
+Czego nie dało się przypiąć do konkretnej lekcji, trafia do `wydarzenia_dnia`
+i `zadania_dnia` (słowniki `data → lista`).
 
 ### Wykres średniej z przedmiotu (Gauge)
 ```yaml

--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ Lub ręcznie:
    - **Hasło**: Twoje hasło do Librus
 4. Kliknij **"Prześlij"**
 
+### Częstotliwość odświeżania
+
+**Ustawienia → Urządzenia i usługi → Librus APIX → Konfiguruj**
+
+Domyślnie integracja odpytuje Librusa **co 2 godziny** (120 minut, zakres 15–1440).
+Zmiana działa od razu — Home Assistant przeładowuje integrację po zapisaniu opcji,
+restart nie jest potrzebny.
+
+Jedno odświeżenie to **8 zapytań HTTP**: oceny, wiadomości, zadania domowe, dane
+ucznia, terminarz (2 miesiące) i plan lekcji (2 tygodnie). Przy 120 minutach daje
+to około 96 zapytań na dobę. Warto o tym pamiętać, schodząc do 15 minut — będzie
+ich wtedy ponad 750.
+
+> Czujniki `Plan lekcji` i `Następna lekcja` przeliczają się **co minutę lokalnie**,
+> bez odpytywania Librusa. Dlatego odliczanie „za X minut" i przeskok na kolejny
+> dzień działają na bieżąco niezależnie od tego, jak rzadko pobierane są dane.
+
 Po dodaniu integracji encje pojawią się w ciągu kilku sekund. Gotowy dashboard
 z planem lekcji wklejasz z pliku
 **[`examples/dashboard-plan-lekcji.yaml`](examples/dashboard-plan-lekcji.yaml)** —

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Integracja Home Assistant z systemem Librus Synergia, umożliwiająca monitorowa
 - 📊 **Monitoring ocen** - wszystkie oceny ze wszystkich przedmiotów
 - 📈 **Statystyki** - średnie ocen, liczba ocen, trend
 - 📧 **Wiadomości** - najnowsze wiadomości z dziennika
+- 🗓️ **Plan lekcji** - bieżący i następny tydzień, z zastępstwami i odwołanymi lekcjami
 - 🔔 **Powiadomienia** - automatyczne powiadomienia o nowych ocenach/wiadomościach
 - 🏠 **Dashboard** - piękne karty w Home Assistant
 
@@ -23,8 +24,13 @@ Integracja tworzy następujące sensory:
 | `sensor.librus_oceny` | Wszystkie oceny bieżącego semestru | liczba ocen |
 | `sensor.librus_srednia_ocen` | **Globalna średnia** ze wszystkich przedmiotów | float (wykres 📈) |
 | `sensor.librus_wiadomosci` | Ostatnie 5 wiadomości z pełną treścią | liczba nieprzeczytanych |
+| `sensor.librus_plan_lekcji` | Plan lekcji na bieżący i następny tydzień | liczba lekcji dzisiaj |
+| `sensor.librus_nastepna_lekcja` | Trwająca lub najbliższa lekcja (odświeżana co minutę) | nazwa przedmiotu |
 | `sensor.librus_<przedmiot>` | Oceny z danego przedmiotu (np. `sensor.librus_matematyka`) | lista ocen: "4, 3+, 5" |
 | `sensor.librus_srednia_<przedmiot>` | **Średnia** z danego przedmiotu (np. `sensor.librus_srednia_matematyka`) | float (wykres 📈) |
+
+Sensor `nastepna_lekcja` przelicza swój stan co minutę lokalnie — **bez dodatkowych zapytań do Librusa**
+(dane planu pobierane są razem z resztą, co 2 godziny).
 
 Sensory średnich mają `state_class: measurement` — HA automatycznie rysuje dla nich wykres historyczny po kliknięciu w encję.
 
@@ -216,6 +222,112 @@ content: >
   {% endfor %} {% else %} Brak nadchodzących zdarzeń. {% endif %}
 ```
 
+### Karta planu lekcji (Mushroom)
+
+> **Wymagane:** [Mushroom Cards](https://github.com/piitaya/lovelace-mushroom) zainstalowane przez HACS.
+> Nazwy encji znajdziesz w **Developer Tools → States** (szukaj `plan_lekcji`).
+
+```yaml
+type: vertical-stack
+cards:
+  - type: custom:mushroom-title-card
+    title: 📚 Plan lekcji
+    subtitle: >-
+      {% set p = 'sensor.librus_imie_nazwisko_plan_lekcji' %}
+      {% set n = states(p) | int(0) %}
+      {% if n > 0 %}
+        Dziś {{ n }} lekcji · {{ state_attr(p, 'pierwsza_lekcja') }}–{{ state_attr(p, 'ostatnia_lekcja') }}
+      {% else %}
+        Dziś brak lekcji 🎉
+      {% endif %}
+
+  - type: custom:mushroom-template-card
+    primary: >-
+      {% set s = 'sensor.librus_imie_nazwisko_nastepna_lekcja' %}
+      {% if states(s) in ['unknown', 'unavailable', 'None'] %}
+        Brak zaplanowanych lekcji
+      {% else %}
+        {{ states(s) }}
+      {% endif %}
+    secondary: >-
+      {% set s = 'sensor.librus_imie_nazwisko_nastepna_lekcja' %}
+      {% if states(s) in ['unknown', 'unavailable', 'None'] %}
+        —
+      {% elif state_attr(s, 'trwa_teraz') %}
+        Trwa do {{ state_attr(s, 'do') }} · sala {{ state_attr(s, 'nauczyciel_sala') }}
+      {% else %}
+        {{ state_attr(s, 'numer') }}. lekcja · {{ state_attr(s, 'od') }} ·
+        za {{ state_attr(s, 'za_minut') }} min
+      {% endif %}
+    icon: >-
+      {% set s = 'sensor.librus_imie_nazwisko_nastepna_lekcja' %}
+      {% if state_attr(s, 'trwa_teraz') %}mdi:school{% else %}mdi:clock-start{% endif %}
+    icon_color: >-
+      {% set s = 'sensor.librus_imie_nazwisko_nastepna_lekcja' %}
+      {% if state_attr(s, 'zastepstwo') %}orange
+      {% elif state_attr(s, 'trwa_teraz') %}green
+      {% else %}blue{% endif %}
+    badge_icon: >-
+      {% if state_attr('sensor.librus_imie_nazwisko_nastepna_lekcja', 'zastepstwo') %}
+        mdi:account-switch
+      {% endif %}
+    badge_color: orange
+
+  - type: conditional
+    conditions:
+      - condition: state
+        entity: sensor.librus_imie_nazwisko_plan_lekcji
+        attribute: sa_zmiany
+        state: true
+    card:
+      type: custom:mushroom-template-card
+      primary: Zmiany w planie
+      secondary: >-
+        {% set z = state_attr('sensor.librus_imie_nazwisko_plan_lekcji', 'zmiany') %}
+        {{ z | count }} zmian w najbliższym tygodniu
+      icon: mdi:calendar-alert
+      icon_color: orange
+
+  - type: markdown
+    content: >-
+      {% set lekcje = state_attr('sensor.librus_imie_nazwisko_plan_lekcji', 'dzisiaj') %}
+      {% if lekcje %} | # | Godzina | Przedmiot | Sala |
+       |---|---------|-----------|------|
+      {% for l in lekcje %} | {{ l.numer }} | {{ l.od }}–{{ l.do }} |
+      {% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo %}**{{ l.przedmiot }}** ⚠️{% else %}{{ l.przedmiot }}{% endif %}
+      | {{ l.nauczyciel_sala }} |
+
+      {% endfor %} {% else %} Dziś nie ma lekcji. {% endif %}
+```
+
+Legenda:
+- 🟢 zielona ikona = lekcja trwa teraz
+- 🟠 pomarańczowa + 🔀 badge = zastępstwo
+- ~~przekreślony~~ przedmiot = lekcja odwołana
+
+### Karta planu na cały tydzień
+
+```yaml
+type: markdown
+title: 🗓️ Plan tygodnia
+content: >-
+  {% set tydzien = state_attr('sensor.librus_imie_nazwisko_plan_lekcji', 'tydzien') %}
+  {% if tydzien %} {% for data, lekcje in tydzien.items() %}
+  **{{ lekcje[0].dzien_tygodnia }} {{ data }}**
+
+  | # | Godzina | Przedmiot | Sala |
+   |---|---------|-----------|------|
+  {% for l in lekcje %} | {{ l.numer }} | {{ l.od }}–{{ l.do }} |
+  {% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo %}**{{ l.przedmiot }}** ⚠️{% else %}{{ l.przedmiot }}{% endif %}
+  | {{ l.nauczyciel_sala }} |
+
+  {% endfor %}
+  {% endfor %} {% else %} Brak danych o planie lekcji. {% endif %}
+```
+
+Atrybut `tydzien` zawiera najbliższe 7 dni (integracja pobiera bieżący i następny tydzień,
+więc w piątek i w weekend widać już kolejny tydzień).
+
 ### Wykres średniej z przedmiotu (Gauge)
 ```yaml
 type: gauge
@@ -285,6 +397,35 @@ automation:
 ```
 
 > **Gdzie znaleźć nazwę telefonu?** HA → Settings → Devices & Services → Mobile App → nazwa urządzenia (np. `notify.mobile_app_samsung_galaxy_s24`)
+
+### 🔀 Powiadomienie o zastępstwie lub odwołanej lekcji
+
+Zdarzenie: `librus_apix_zmiana_planu`
+Dostępne dane: `data`, `dzien_tygodnia`, `numer`, `przedmiot`, `od`, `do`, `rodzaj` (`zastepstwo` / `odwolana`), `info`
+
+```yaml
+automation:
+  - alias: "Librus - zmiana w planie lekcji"
+    trigger:
+      platform: event
+      event_type: librus_apix_zmiana_planu
+    action:
+      - service: notify.mobile_app_NAZWA_TWOJEGO_TELEFONU
+        data:
+          title: >-
+            {% if trigger.event.data.rodzaj == 'odwolana' %}
+              🚫 Lekcja odwołana
+            {% else %}
+              🔀 Zastępstwo
+            {% endif %}
+          message: >-
+            {{ trigger.event.data.dzien_tygodnia }} {{ trigger.event.data.data }},
+            {{ trigger.event.data.numer }}. lekcja ({{ trigger.event.data.od }}):
+            {{ trigger.event.data.przedmiot }}
+```
+
+> Pierwsze uruchomienie integracji tylko zapamiętuje bieżący stan planu — powiadomienia
+> przychodzą dopiero o **nowo wykrytych** zmianach.
 
 ## 🛠️ Rozwój
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,76 @@ Legenda ikon:
 - ⚫ szara = przeczytana
 - 📎 badge = ma załącznik
 
+### Złożenie kart w widok jednokolumnowy
+
+Trzy karty poniżej dobrze czytają się jedna pod drugą, w kolejności:
+**Nadchodzące wydarzenia → Plan lekcji → Plan tygodnia**.
+
+> **Uwaga:** `max_columns: 1` w widoku **nie zadziała**. Domyślny widok Lovelace
+> (masonry) ma puste `setConfig()` i liczy kolumny wyłącznie z szerokości ekranu,
+> ignorując konfigurację. Jedyny pewny sposób na jedną kolumnę to opakowanie
+> wszystkiego w pojedynczy `vertical-stack` — widok dostaje wtedy jedną kartę,
+> więc nie ma czego rozkładać na kolumny.
+
+```yaml
+views:
+  - title: Plan lekcji
+    path: plan
+    icon: mdi:timetable
+    cards:
+      - type: vertical-stack
+        cards:
+          # 1. wklej tu zawartość karty "Nadchodzące wydarzenia"
+          # 2. potem kartę "Plan lekcji (Mushroom)"
+          # 3. na końcu kartę "Plan tygodnia"
+```
+
+Karty „Nadchodzące wydarzenia" i „Plan lekcji" same są `vertical-stack` —
+zagnieżdżanie stosów jest w Lovelace poprawne, wklejasz je bez zmian.
+
+### Karta nadchodzących wydarzeń (4 tygodnie)
+
+> Korzysta z sensora `terminarz`, który pobiera bieżący i następny miesiąc.
+> **4 tygodnie to maksimum, jakie ten sensor gwarantuje.** Najkrótszy możliwy
+> horyzont wypada 31 stycznia (do 28 lutego) i wynosi dokładnie 28 dni — dłuższy
+> okres po cichu urywałby się na końcu następnego miesiąca.
+
+```yaml
+type: vertical-stack
+cards:
+  - type: custom:mushroom-title-card
+    title: 📅 Nadchodzące wydarzenia
+    subtitle: >-
+      {% set z = state_attr('sensor.librus_imie_nazwisko_terminarz', 'zdarzenia') or [] %}
+      {% set do = (now() + timedelta(days=28)).strftime('%Y-%m-%d') %}
+      {% set n = z | selectattr('data', 'le', do) | list | count %}
+      {% set r = n % 10 %}{% set s = n % 100 %}
+      {% if n == 0 %}Najbliższe 4 tygodnie bez wydarzeń{% else %}{{ n }}
+      {% if n == 1 %}wydarzenie{% elif r in [2, 3, 4] and s not in [12, 13, 14] %}wydarzenia{% else %}wydarzeń{% endif %}
+      w najbliższych 4 tygodniach{% endif %}
+
+  - type: markdown
+    content: |-
+      {%- set wszystkie = state_attr('sensor.librus_imie_nazwisko_terminarz', 'zdarzenia') or [] %}
+      {%- set do = (now() + timedelta(days=28)).strftime('%Y-%m-%d') %}
+      {%- set zdarzenia = wszystkie | selectattr('data', 'le', do) | list %}
+      {%- set testy = ['sprawdzian', 'kartkówka', 'klasówka', 'praca klasowa'] %}
+      {%- if zdarzenia %}
+      | Data | Dzień | Wydarzenie | Przedmiot | Szczegóły |
+      |------|-------|------------|-----------|-----------|
+      {%- for z in zdarzenia %}
+      {%- set k = '#e53935' if z.tytul | lower in testy else '' %}
+      {%- set opis = z.szczegoly.Opis if z.szczegoly.Opis not in [none, '', 'unknown'] else '' %}
+      | {% if k %}<font color="{{ k }}">**{% endif %}{{ z.data }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ z.tydzien }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ z.tytul }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ z.przedmiot }}{% if k %}**</font>{% endif %} | {{ opis }}{% if z.godzina not in ['', 'unknown', none] %}{% if opis %} · {% endif %}{{ z.godzina }}{% endif %} |
+      {%- endfor %}
+      {%- else %}
+      Brak wydarzeń w najbliższych 4 tygodniach.
+      {%- endif %}
+```
+
+Sprawdziany i kartkówki są <font color="#e53935">**czerwone i pogrubione**</font> —
+tak samo jak w planie lekcji. Horyzont skrócisz podmieniając `days=28` — zwiększać nie ma sensu (patrz uwaga wyżej).
+
 ### Karta terminarza (wszystkie zdarzenia)
 
 > Znajdź nazwę encji w **Developer Tools → States** (szukaj `terminarz`).
@@ -315,7 +385,8 @@ cards:
       | # | Godzina | Przedmiot | Sala |
       |---|---------|-----------|------|
       {%- for l in lekcje %}
-      | {{ l.numer }} | {{ l.od }}–{{ l.do }} | {% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo %}**{{ l.przedmiot }}** ⚠️{% else %}{{ l.przedmiot }}{% endif %}{% for w in l.wydarzenia %} 📝 {{ w.tytul }}{% endfor %}{% for z in l.zadania %} 📚 {{ z.kategoria }}{% endfor %} | {{ l.nauczyciel_sala }} |
+      {%- set k = '#e53935' if l.wydarzenia else ('#f9a825' if l.zadania else '') %}
+      | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.numer }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.od }}–{{ l.do }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo and not k %}**{{ l.przedmiot }}** ⚠️{% elif l.zastepstwo %}{{ l.przedmiot }} ⚠️{% else %}{{ l.przedmiot }}{% endif %}{% for w in l.wydarzenia %} 📝 {{ w.tytul }}{% endfor %}{% for z in l.zadania %} 📚 {{ z.kategoria }}{% endfor %}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.nauczyciel_sala }}{% if k %}**</font>{% endif %} |
       {%- endfor %}
       {%- else %}
       Brak nadchodzących lekcji.
@@ -329,6 +400,14 @@ Legenda:
 - 📝 przy przedmiocie = wydarzenie z terminarza (sprawdzian, kartkówka)
 - 📚 przy przedmiocie = praca domowa na ten dzień
 - 📌 nad tabelą = wydarzenie całodniowe (wywiadówka, dzień wolny)
+- <font color="#e53935">**czerwony pogrubiony wiersz**</font> = tego dnia jest sprawdzian/kartkówka z tego przedmiotu
+- <font color="#f9a825">**żółty pogrubiony wiersz**</font> = na ten dzień jest praca domowa
+
+> **Dlaczego kolor tekstu, a nie tło wiersza?** Karta markdown w Home Assistant
+> przepuszcza treść przez sanitizer (biblioteka `xss`), który usuwa atrybuty
+> `style`, `class` i `bgcolor` ze znaczników `<tr>` i `<td>`. Tła wiersza nie da się
+> więc ustawić bez dodatkowych modułów z HACS. Znacznik `<font color>` jest na
+> białej liście i działa bez żadnych instalacji.
 
 ### Karta planu na cały tydzień
 
@@ -355,7 +434,8 @@ content: |-
   | # | Godzina | Przedmiot | Sala |
   |---|---------|-----------|------|
   {%- for l in lekcje %}
-  | {{ l.numer }} | {{ l.od }}–{{ l.do }} | {% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo %}**{{ l.przedmiot }}** ⚠️{% else %}{{ l.przedmiot }}{% endif %}{% for w in l.wydarzenia %} 📝 {{ w.tytul }}{% endfor %}{% for z in l.zadania %} 📚 {{ z.kategoria }}{% endfor %} | {{ l.nauczyciel_sala }} |
+  {%- set k = '#e53935' if l.wydarzenia else ('#f9a825' if l.zadania else '') %}
+  | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.numer }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.od }}–{{ l.do }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo and not k %}**{{ l.przedmiot }}** ⚠️{% elif l.zastepstwo %}{{ l.przedmiot }} ⚠️{% else %}{{ l.przedmiot }}{% endif %}{% for w in l.wydarzenia %} 📝 {{ w.tytul }}{% endfor %}{% for z in l.zadania %} 📚 {{ z.kategoria }}{% endfor %}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.nauczyciel_sala }}{% if k %}**</font>{% endif %} |
   {%- endfor %}
   {% endfor %}
   {%- else %}

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,5 +1,10 @@
 # Basic configuration for testing Librus APIX integration
 
+# Bez tego HA startuje w UTC, a szablony uzywajace now() pokazuja
+# godziny przesuniete wzgledem zegara uzytkownika.
+homeassistant:
+  time_zone: Europe/Warsaw
+
 default_config:
 
 # Logger configuration for debugging
@@ -47,33 +52,13 @@ automation:
           message: "{{ trigger.to_state.state }}"
           notification_id: "new_message"
 
-# Example sensor for grade average tracking
-sensor:
-  - platform: template
-    sensors:
-      librus_grade_trend:
-        friendly_name: "Grade Trend"
-        value_template: >-
-          {% set avg = states('sensor.librus_average_grade') | float %}
-          {% if avg >= 5.0 %}
-            Excellent
-          {% elif avg >= 4.5 %}
-            Very Good
-          {% elif avg >= 4.0 %}
-            Good
-          {% elif avg >= 3.5 %}
-            Satisfactory
-          {% else %}
-            Needs Improvement
-          {% endif %}
-        icon_template: >-
-          {% set avg = states('sensor.librus_average_grade') | float %}
-          {% if avg >= 5.0 %}
-            mdi:trophy
-          {% elif avg >= 4.5 %}
-            mdi:medal
-          {% elif avg >= 4.0 %}
-            mdi:thumb-up
-          {% else %}
-            mdi:alert-circle
-          {% endif %}
+# --- Podglad demonstracyjny planu lekcji (bez konta Librusa) ---
+# Atrapy sensorow o takich samych nazwach i atrybutach jak encje integracji.
+template: !include_dir_merge_list template_config
+
+# Dashboard w trybie YAML + karty Mushroom serwowane z config/www/
+lovelace:
+  mode: yaml
+  resources:
+    - url: /local/mushroom.js
+      type: module

--- a/config/demo_bez_librusa/README.txt
+++ b/config/demo_bez_librusa/README.txt
@@ -1,0 +1,3 @@
+Atrapy sensorow planu lekcji do podgladu kart bez konta w Librusie.
+Aby wlaczyc: przenies demo_librus.yaml do config/template_config/
+oraz demo_plan.jinja do config/custom_templates/ i zrestartuj HA.

--- a/config/demo_bez_librusa/demo_librus.yaml
+++ b/config/demo_bez_librusa/demo_librus.yaml
@@ -1,0 +1,78 @@
+# Atrapy sensorow Librusa do podgladu kart Lovelace bez konta w dzienniku.
+# Encje maja te same nazwy i atrybuty co te tworzone przez integracje,
+# wiec karty z README dzialaja na nich bez zadnych zmian.
+# Szablony uzywaja now(), wiec Home Assistant przelicza je co minute.
+
+- sensor:
+    - name: "Librus Jan Kowalski Plan lekcji"
+      unique_id: demo_librus_plan_lekcji
+      icon: mdi:timetable
+      state: >-
+        {% from 'demo_plan.jinja' import plan_dnia %}
+        {{ (plan_dnia(0, 90) | from_json) | count }}
+      attributes:
+        dzisiaj: >-
+          {% from 'demo_plan.jinja' import plan_dnia %}
+          {{ plan_dnia(0, 90) | from_json }}
+        jutro: >-
+          {% from 'demo_plan.jinja' import plan_dnia %}
+          {{ plan_dnia(1, 90) | from_json }}
+        tydzien: >-
+          {% from 'demo_plan.jinja' import plan_tygodnia %}
+          {{ plan_tygodnia() | from_json }}
+        liczba_lekcji_dzisiaj: >-
+          {% from 'demo_plan.jinja' import plan_dnia %}
+          {{ (plan_dnia(0, 90) | from_json) | count }}
+        pierwsza_lekcja: >-
+          {% from 'demo_plan.jinja' import plan_dnia %}
+          {{ (plan_dnia(0, 90) | from_json)[0]['od'] }}
+        ostatnia_lekcja: >-
+          {% from 'demo_plan.jinja' import plan_dnia %}
+          {{ (plan_dnia(0, 90) | from_json)[-1]['do'] }}
+        zmiany: >-
+          {% from 'demo_plan.jinja' import plan_dnia %}
+          {{ (plan_dnia(0, 90) | from_json)
+             | selectattr('info', 'ne', '') | list }}
+        sa_zmiany: >-
+          {% from 'demo_plan.jinja' import plan_dnia %}
+          {{ (plan_dnia(0, 90) | from_json)
+             | selectattr('info', 'ne', '') | list | count > 0 }}
+
+    - name: "Librus Jan Kowalski Nastepna lekcja"
+      unique_id: demo_librus_nastepna_lekcja
+      icon: mdi:clock-start
+      state: >-
+        {% from 'demo_plan.jinja' import nastepna_lekcja %}
+        {% set l = nastepna_lekcja() | from_json %}
+        {{ l['przedmiot'] if l else None }}
+      attributes:
+        data: >-
+          {% from 'demo_plan.jinja' import nastepna_lekcja %}
+          {{ (nastepna_lekcja() | from_json).get('data') }}
+        dzien_tygodnia: >-
+          {% from 'demo_plan.jinja' import nastepna_lekcja %}
+          {{ (nastepna_lekcja() | from_json).get('dzien_tygodnia') }}
+        numer: >-
+          {% from 'demo_plan.jinja' import nastepna_lekcja %}
+          {{ (nastepna_lekcja() | from_json).get('numer') }}
+        od: >-
+          {% from 'demo_plan.jinja' import nastepna_lekcja %}
+          {{ (nastepna_lekcja() | from_json).get('od') }}
+        do: >-
+          {% from 'demo_plan.jinja' import nastepna_lekcja %}
+          {{ (nastepna_lekcja() | from_json).get('do') }}
+        nauczyciel_sala: >-
+          {% from 'demo_plan.jinja' import nastepna_lekcja %}
+          {{ (nastepna_lekcja() | from_json).get('nauczyciel_sala') }}
+        za_minut: >-
+          {% from 'demo_plan.jinja' import nastepna_lekcja %}
+          {{ (nastepna_lekcja() | from_json).get('za_minut') }}
+        trwa_teraz: >-
+          {% from 'demo_plan.jinja' import nastepna_lekcja %}
+          {{ (nastepna_lekcja() | from_json).get('trwa_teraz') }}
+        zastepstwo: >-
+          {% from 'demo_plan.jinja' import nastepna_lekcja %}
+          {{ (nastepna_lekcja() | from_json).get('zastepstwo') }}
+        info: >-
+          {% from 'demo_plan.jinja' import nastepna_lekcja %}
+          {{ (nastepna_lekcja() | from_json).get('info') }}

--- a/config/demo_bez_librusa/demo_plan.jinja
+++ b/config/demo_bez_librusa/demo_plan.jinja
@@ -1,0 +1,79 @@
+{#- Atrapa planu lekcji do podgladu kart Lovelace bez konta Librusa.
+    Zwraca te sama strukture, co atrybuty sensora sensor.*_plan_lekcji.
+    Makra oddaja JSON - u konsumenta trzeba uzyc filtra | from_json. -#}
+
+{%- macro plan_dnia(przesuniecie_dni, kotwica_minuty) -%}
+  {#- Lekcje sa zakotwiczone wzgledem biezacej godziny, dzieki czemu
+      "trwa teraz" i "za X minut" widac o kazdej porze dnia. -#}
+  {%- set przedmioty = [
+        ('Matematyka', 'Kowalska - 12', false, false),
+        ('Jezyk polski', 'Nowak - 8', false, false),
+        ('Fizyka', 'Zielinski - 21', true, false),
+        ('Wychowanie fizyczne', 'Lis - sala gimn.', false, false),
+        ('Historia', 'Mazur - 5', false, true),
+        ('Chemia', 'Dabrowska - 19', false, false),
+        ('Jezyk angielski', 'Wisniewski - 3', false, false)
+      ] -%}
+  {%- set start0 = (now().replace(second=0, microsecond=0)
+                    + timedelta(days=przesuniecie_dni)
+                    - timedelta(minutes=kotwica_minuty)) -%}
+  {%- set dni = ['Poniedzialek','Wtorek','Sroda','Czwartek','Piatek','Sobota','Niedziela'] -%}
+  {%- set ns = namespace(lekcje=[]) -%}
+  {%- for p in przedmioty -%}
+    {%- set od = start0 + timedelta(minutes=55 * loop.index0) -%}
+    {%- set koniec = od + timedelta(minutes=45) -%}
+    {%- set ns.lekcje = ns.lekcje + [{
+          'data': od.strftime('%Y-%m-%d'),
+          'dzien_tygodnia': dni[od.weekday()],
+          'numer': loop.index,
+          'przedmiot': p[0],
+          'nauczyciel_sala': p[1],
+          'od': od.strftime('%H:%M'),
+          'do': koniec.strftime('%H:%M'),
+          'przerwa_od': koniec.strftime('%H:%M'),
+          'przerwa_do': (koniec + timedelta(minutes=10)).strftime('%H:%M'),
+          'odwolana': p[3],
+          'zastepstwo': p[2],
+          'info': 'Zastepstwo' if p[2] else ('Lekcja odwolana' if p[3] else ''),
+          'szczegoly': {}
+        }] -%}
+  {%- endfor -%}
+  {{- ns.lekcje | tojson -}}
+{%- endmacro -%}
+
+{%- macro plan_tygodnia() -%}
+  {#- Piaskownica Jinja w HA blokuje dict.update(), wiec skladamy JSON recznie. -#}
+  {%- set ns = namespace(dni=[]) -%}
+  {%- for d in range(0, 9) -%}
+    {%- if ns.dni | count < 5 -%}
+      {%- set lekcje = plan_dnia(d, 90) | from_json -%}
+      {%- if lekcje[0]['dzien_tygodnia'] not in ['Sobota', 'Niedziela'] -%}
+        {%- set ns.dni = ns.dni + [lekcje] -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {{- '{' -}}
+  {%- for lekcje in ns.dni -%}
+    {{- (lekcje[0]['data'] | tojson) ~ ':' ~ (lekcje | tojson) -}}
+    {{- ',' if not loop.last else '' -}}
+  {%- endfor -%}
+  {{- '}' -}}
+{%- endmacro -%}
+
+{%- macro nastepna_lekcja() -%}
+  {#- Pierwsza nieodwolana lekcja, ktora sie jeszcze nie skonczyla. -#}
+  {%- set lekcje = plan_dnia(0, 90) | from_json -%}
+  {%- set teraz = now().strftime('%H:%M') -%}
+  {%- set ns = namespace(wynik={}) -%}
+  {%- for l in lekcje -%}
+    {%- if not l['odwolana'] and l['do'] > teraz and not ns.wynik -%}
+      {%- set trwa = l['od'] <= teraz -%}
+      {%- set ns.wynik = dict(l, trwa_teraz=trwa, za_minut=(
+            0 if trwa else
+            ((l['od'][:2] | int) * 60 + (l['od'][3:] | int))
+            - ((teraz[:2] | int) * 60 + (teraz[3:] | int))
+          )) -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {{- ns.wynik | tojson -}}
+{%- endmacro -%}

--- a/config/template_config/legacy_grade_trend.yaml
+++ b/config/template_config/legacy_grade_trend.yaml
@@ -1,0 +1,19 @@
+# Zmigrowane z przestarzalego "sensor: - platform: template" w configuration.yaml.
+# Aktualne Home Assistant odrzuca tamten zapis: szablony musza byc pod kluczem "template".
+# Uwaga: encja zrodlowa pochodzi ze starego nazewnictwa integracji i moze nie istniec.
+- sensor:
+    - name: "Grade Trend"
+      unique_id: legacy_librus_grade_trend
+      state: >-
+        {% set avg = states('sensor.librus_average_grade') | float(0) %}
+        {% if avg >= 5.0 %}Excellent
+        {% elif avg >= 4.5 %}Very Good
+        {% elif avg >= 4.0 %}Good
+        {% elif avg >= 3.5 %}Satisfactory
+        {% else %}Needs Improvement{% endif %}
+      icon: >-
+        {% set avg = states('sensor.librus_average_grade') | float(0) %}
+        {% if avg >= 5.0 %}mdi:trophy
+        {% elif avg >= 4.5 %}mdi:medal
+        {% elif avg >= 4.0 %}mdi:thumb-up
+        {% else %}mdi:alert-circle{% endif %}

--- a/custom_components/librus_apix/__init__.py
+++ b/custom_components/librus_apix/__init__.py
@@ -17,6 +17,7 @@ from librus_apix.client import Client, new_client
 from librus_apix.exceptions import TokenError
 
 from .const import DOMAIN, SCAN_INTERVAL
+from .plan_lekcji import przetworz_plan
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -297,6 +298,61 @@ class LibrusApiClient:
             except Exception as ex:
                 _LOGGER.error(
                     "Failed to get schedule (attempt %d/2): %s\n%s",
+                    attempt + 1, ex, traceback.format_exc(),
+                )
+                self._reset_auth()
+                if attempt == 1:
+                    return None
+
+    async def async_get_timetable(self):
+        """Get lesson timetable from Librus (current and next week).
+
+        A failure to parse one week (e.g. a holiday week with no periods) is
+        tolerated - the remaining week is still returned.
+        """
+        for attempt in range(2):
+            try:
+                if not self._client or not self._token:
+                    if not await self.async_authenticate():
+                        return None
+
+                from librus_apix.timetable import get_timetable
+                from librus_apix.exceptions import ParseError
+                from datetime import datetime as _datetime, timedelta
+
+                today = date.today()
+                monday = today - timedelta(days=today.weekday())
+                loop = asyncio.get_running_loop()
+
+                def _fetch_two_weeks():
+                    weeks = []
+                    for offset in (0, 7):
+                        start = _datetime.combine(
+                            monday + timedelta(days=offset), _datetime.min.time()
+                        )
+                        try:
+                            weeks.append(get_timetable(self._client, start))
+                        except ParseError as parse_err:
+                            _LOGGER.debug(
+                                "Brak planu lekcji dla tygodnia od %s: %s",
+                                start.date(), parse_err,
+                            )
+                    return przetworz_plan(weeks)
+
+                return await loop.run_in_executor(None, _fetch_two_weeks)
+
+            except TokenError:
+                _LOGGER.warning(
+                    "Token expired fetching timetable (attempt %d/2), re-authenticating...",
+                    attempt + 1,
+                )
+                self._reset_auth()
+                if attempt == 1:
+                    _LOGGER.error("Failed to get timetable after re-authentication.")
+                    return None
+            except Exception as ex:
+                _LOGGER.error(
+                    "Failed to get timetable (attempt %d/2): %s\n%s",
                     attempt + 1, ex, traceback.format_exc(),
                 )
                 self._reset_auth()

--- a/custom_components/librus_apix/__init__.py
+++ b/custom_components/librus_apix/__init__.py
@@ -17,7 +17,7 @@ from librus_apix.client import Client, new_client
 from librus_apix.exceptions import TokenError
 
 from .const import DOMAIN, SCAN_INTERVAL
-from .plan_lekcji import przetworz_plan
+from .plan_lekcji import DNI_TYGODNIA_PL, przetworz_plan
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -274,7 +274,10 @@ class LibrusApiClient:
                             for ev in day_events:
                                 events.append({
                                     "data": event_date.strftime("%Y-%m-%d"),
-                                    "tydzien": event_date.strftime("%A"),
+                                    "tydzien": DNI_TYGODNIA_PL.get(
+                                        event_date.strftime("%A"),
+                                        event_date.strftime("%A"),
+                                    ),
                                     "tytul": ev.title,
                                     "przedmiot": ev.subject,
                                     "godzina": ev.hour,

--- a/custom_components/librus_apix/config_flow.py
+++ b/custom_components/librus_apix/config_flow.py
@@ -6,11 +6,19 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
 
 from librus_apix.client import new_client
 
-from .const import DOMAIN
+from .const import (
+    CONF_SCAN_INTERVAL_MINUTES,
+    DEFAULT_SCAN_INTERVAL_MINUTES,
+    DOMAIN,
+    MAX_SCAN_INTERVAL_MINUTES,
+    MIN_SCAN_INTERVAL_MINUTES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,6 +57,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> "OptionsFlowHandler":
+        """Zwroc obsluge opcji integracji."""
+        return OptionsFlowHandler()
+
     async def async_step_user(
         self, user_input: dict | None = None
     ) -> FlowResult:
@@ -71,3 +87,38 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=STEP_USER_DATA_SCHEMA, 
             errors=errors
         )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
+    """Opcje integracji - na razie tylko czestotliwosc odpytywania Librusa.
+
+    OptionsFlowWithReload sam przeladowuje wpis po zapisaniu opcji, wiec nowy
+    interwal zaczyna obowiazywac od razu, bez restartu Home Assistanta.
+    """
+
+    async def async_step_init(
+        self, user_input: dict | None = None
+    ) -> FlowResult:
+        """Formularz opcji."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        biezacy = self.config_entry.options.get(
+            CONF_SCAN_INTERVAL_MINUTES, DEFAULT_SCAN_INTERVAL_MINUTES
+        )
+        schemat = vol.Schema(
+            {
+                vol.Required(
+                    CONF_SCAN_INTERVAL_MINUTES, default=biezacy
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=MIN_SCAN_INTERVAL_MINUTES,
+                        max=MAX_SCAN_INTERVAL_MINUTES,
+                        step=5,
+                        unit_of_measurement="min",
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                )
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schemat)

--- a/custom_components/librus_apix/const.py
+++ b/custom_components/librus_apix/const.py
@@ -14,3 +14,6 @@ SCAN_INTERVAL = timedelta(hours=2)
 
 # Default values
 DEFAULT_MESSAGES_COUNT = 10
+
+# Ile dni lekcyjnych pokazuje czujnik planu
+DEFAULT_PLAN_DAYS = 5

--- a/custom_components/librus_apix/const.py
+++ b/custom_components/librus_apix/const.py
@@ -12,6 +12,14 @@ CONF_PASSWORD = "password"
 # Update intervals
 SCAN_INTERVAL = timedelta(hours=2)
 
+# Interwal odpytywania Librusa, konfigurowalny w opcjach integracji.
+# Jeden cykl to 8 zapytan HTTP (oceny, wiadomosci, zadania, uczen,
+# 2x terminarz, 2x plan lekcji), wiec nie schodzimy ponizej 15 minut.
+CONF_SCAN_INTERVAL_MINUTES = "scan_interval_minutes"
+DEFAULT_SCAN_INTERVAL_MINUTES = 120
+MIN_SCAN_INTERVAL_MINUTES = 15
+MAX_SCAN_INTERVAL_MINUTES = 1440
+
 # Default values
 DEFAULT_MESSAGES_COUNT = 10
 

--- a/custom_components/librus_apix/manifest.json
+++ b/custom_components/librus_apix/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/LukMaverick/LibrusSynergiaHA/issues",
   "requirements": ["librus-apix>=1.5.1", "aiohttp"],
-  "version": "1.1.5"
+  "version": "1.2.0"
 }

--- a/custom_components/librus_apix/plan_lekcji.py
+++ b/custom_components/librus_apix/plan_lekcji.py
@@ -137,3 +137,150 @@ def nastepna_lekcja(
         return {**lekcja, "trwa_teraz": trwa, "za_minut": pozostalo}
 
     return None
+
+
+def _koniec_dnia(lekcje: List[Dict[str, Any]]) -> Optional[datetime]:
+    """Zwroc moment zakonczenia ostatniej lekcji dnia (None gdy brak godzin)."""
+    konce = [_polacz(l["data"], l["do"]) for l in lekcje]
+    konce = [k for k in konce if k is not None]
+    return max(konce) if konce else None
+
+
+def dni_do_wyswietlenia(
+    plan: List[Dict[str, Any]], teraz: datetime
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Dni, ktorych ostatnia lekcja jeszcze sie nie skonczyla.
+
+    Dzien bez czytelnych godzin zostaje zachowany - lepiej pokazac za duzo
+    niz ukryc dane, ktorych nie umiemy zinterpretowac.
+    """
+    wynik: Dict[str, List[Dict[str, Any]]] = {}
+    for data, lekcje in pogrupuj_wg_dni(plan).items():
+        koniec = _koniec_dnia(lekcje)
+        if koniec is None or koniec > teraz:
+            wynik[data] = lekcje
+    return wynik
+
+
+def biezacy_dzien(
+    plan: List[Dict[str, Any]], teraz: datetime
+) -> List[Dict[str, Any]]:
+    """Lekcje dnia, ktory ma sens pokazac: dzisiejsze dopoki trwaja,
+    a po ostatniej lekcji - najblizszy kolejny dzien z lekcjami."""
+    for lekcje in dni_do_wyswietlenia(plan, teraz).values():
+        return lekcje
+    return []
+
+
+def _numer_lekcji(wartosc: Any) -> Optional[int]:
+    """Zamien numer lekcji z terminarza na int.
+
+    Librus zwraca tu liczbe albo napis "unknown" dla wydarzen calodniowych.
+    """
+    if isinstance(wartosc, bool):
+        return None
+    if isinstance(wartosc, int):
+        return wartosc
+    if isinstance(wartosc, str) and wartosc.strip().isdigit():
+        return int(wartosc.strip())
+    return None
+
+
+def _klucz_przedmiotu(nazwa: str) -> str:
+    """Znormalizuj nazwe przedmiotu do porownan (terminarz bywa inaczej pisany)."""
+    return (nazwa or "").strip().casefold()
+
+
+def _data_iso(wartosc: str) -> Optional[str]:
+    """Sprowadz date do formatu YYYY-MM-DD, tolerujac zapis z kropkami."""
+    tekst = (wartosc or "").strip()
+    for fmt in ("%Y-%m-%d", "%d.%m.%Y", "%Y.%m.%d", "%d-%m-%Y"):
+        try:
+            return datetime.strptime(tekst, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return None
+
+
+def _skrot_wydarzenia(zdarzenie: Dict[str, Any]) -> Dict[str, Any]:
+    """Zostaw z wydarzenia tylko to, co przydaje sie na karcie."""
+    szczegoly = zdarzenie.get("szczegoly") or {}
+    return {
+        "tytul": zdarzenie.get("tytul", ""),
+        "przedmiot": zdarzenie.get("przedmiot", ""),
+        "opis": szczegoly.get("Opis", "") if isinstance(szczegoly, dict) else "",
+        "nauczyciel": szczegoly.get("Nauczyciel", "") if isinstance(szczegoly, dict) else "",
+        "godzina": zdarzenie.get("godzina", ""),
+    }
+
+
+def _skrot_zadania(zadanie: Dict[str, Any]) -> Dict[str, Any]:
+    """Zostaw z zadania domowego tylko to, co przydaje sie na karcie."""
+    return {
+        "przedmiot": zadanie.get("przedmiot", ""),
+        "kategoria": zadanie.get("kategoria", ""),
+        "termin": zadanie.get("termin", ""),
+        "nauczyciel": zadanie.get("nauczyciel", ""),
+    }
+
+
+def polacz_z_wydarzeniami(
+    plan: List[Dict[str, Any]],
+    terminarz: Optional[List[Dict[str, Any]]] = None,
+    zadania: Optional[List[Dict[str, Any]]] = None,
+) -> tuple:
+    """Przypnij wydarzenia z terminarza i prace domowe do lekcji.
+
+    Dopasowanie wydarzenia: najpierw po numerze lekcji (gdy Librus go poda),
+    potem po nazwie przedmiotu. Czego nie da sie przypiac do konkretnej lekcji
+    (wywiadowka, dzien wolny), trafia do wydarzen calodniowych.
+
+    Prace domowe przypinane sa do dnia, w ktorym mija ich termin.
+
+    Returns:
+        (plan z polami "wydarzenia" i "zadania", wydarzenia_dnia, zadania_dnia)
+    """
+    wzbogacony = [{**l, "wydarzenia": [], "zadania": []} for l in plan]
+    wg_dnia: Dict[str, List[Dict[str, Any]]] = {}
+    for lekcja in wzbogacony:
+        wg_dnia.setdefault(lekcja["data"], []).append(lekcja)
+
+    wydarzenia_dnia: Dict[str, List[Dict[str, Any]]] = {}
+    zadania_dnia: Dict[str, List[Dict[str, Any]]] = {}
+
+    def _dopasuj(dzien: str, przedmiot: str, numer: Optional[int]) -> List[Dict[str, Any]]:
+        lekcje = wg_dnia.get(dzien, [])
+        if numer is not None:
+            trafienia = [l for l in lekcje if l["numer"] == numer]
+            if trafienia:
+                return trafienia
+        klucz = _klucz_przedmiotu(przedmiot)
+        return [l for l in lekcje if klucz and _klucz_przedmiotu(l["przedmiot"]) == klucz]
+
+    for zdarzenie in terminarz or []:
+        dzien = _data_iso(zdarzenie.get("data", ""))
+        if dzien is None:
+            continue
+        skrot = _skrot_wydarzenia(zdarzenie)
+        trafienia = _dopasuj(
+            dzien, zdarzenie.get("przedmiot", ""), _numer_lekcji(zdarzenie.get("numer_lekcji"))
+        )
+        if trafienia:
+            for lekcja in trafienia:
+                lekcja["wydarzenia"].append(skrot)
+        elif dzien in wg_dnia:
+            wydarzenia_dnia.setdefault(dzien, []).append(skrot)
+
+    for zadanie in zadania or []:
+        dzien = _data_iso(zadanie.get("termin", ""))
+        if dzien is None:
+            continue
+        skrot = _skrot_zadania(zadanie)
+        trafienia = _dopasuj(dzien, zadanie.get("przedmiot", ""), None)
+        if trafienia:
+            for lekcja in trafienia:
+                lekcja["zadania"].append(skrot)
+        elif dzien in wg_dnia:
+            zadania_dnia.setdefault(dzien, []).append(skrot)
+
+    return wzbogacony, wydarzenia_dnia, zadania_dnia

--- a/custom_components/librus_apix/plan_lekcji.py
+++ b/custom_components/librus_apix/plan_lekcji.py
@@ -8,12 +8,13 @@ from datetime import date, datetime
 from typing import Any, Dict, Iterable, List, Optional
 
 # Nazwy dni tygodnia zwracane przez librus_apix.timetable.Period.weekday
+# Wartosci trafiaja wprost na karty, wiec z polskimi znakami.
 DNI_TYGODNIA_PL = {
-    "Monday": "Poniedzialek",
+    "Monday": "Poniedzia\u0142ek",
     "Tuesday": "Wtorek",
-    "Wednesday": "Sroda",
+    "Wednesday": "\u015aroda",
     "Thursday": "Czwartek",
-    "Friday": "Piatek",
+    "Friday": "Pi\u0105tek",
     "Saturday": "Sobota",
     "Sunday": "Niedziela",
 }

--- a/custom_components/librus_apix/plan_lekcji.py
+++ b/custom_components/librus_apix/plan_lekcji.py
@@ -1,0 +1,139 @@
+"""Czysta logika przetwarzania planu lekcji z Librusa.
+
+Modul celowo nie importuje Home Assistanta ani biblioteki librus_apix,
+dzieki czemu da sie go testowac samodzielnie.
+"""
+
+from datetime import date, datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+# Nazwy dni tygodnia zwracane przez librus_apix.timetable.Period.weekday
+DNI_TYGODNIA_PL = {
+    "Monday": "Poniedzialek",
+    "Tuesday": "Wtorek",
+    "Wednesday": "Sroda",
+    "Thursday": "Czwartek",
+    "Friday": "Piatek",
+    "Saturday": "Sobota",
+    "Sunday": "Niedziela",
+}
+
+
+# Mapowanie polskich znakow diakrytycznych na ASCII - etykiety z Librusa
+# ("Zastepstwo", "Lekcja odwolana") pisane sa z ogonkami.
+_OGONKI = str.maketrans(
+    "\u0105\u0107\u0119\u0142\u0144\u00f3\u015b\u017a\u017c",
+    "acelnoszz",
+)
+
+
+def _zawiera(tekst: str, *rdzenie: str) -> bool:
+    """Sprawdz czy tekst zawiera ktorykolwiek z rdzeni, ignorujac wielkosc liter i ogonki."""
+    maly = tekst.lower().translate(_OGONKI)
+    return any(rdzen in maly for rdzen in rdzenie)
+
+
+def _opis_zmiany(info: Dict[str, Any]) -> str:
+    """Zwroc etykiete zmiany (np. 'Zastepstwo') z pola info okresu."""
+    return "; ".join(k.strip() for k in info.keys() if k and k.strip()) if info else ""
+
+
+def przetworz_plan(tygodnie: Iterable[Iterable[Iterable[Any]]]) -> List[Dict[str, Any]]:
+    """Zamien surowy plan z librus_apix na plaska, posortowana liste lekcji.
+
+    Args:
+        tygodnie: kolekcja tygodni, gdzie kazdy tydzien to lista dni,
+            a kazdy dzien to lista obiektow Period.
+
+    Returns:
+        Lista slownikow z polskimi kluczami, posortowana po dacie i numerze lekcji.
+        Puste okienka (Period bez przedmiotu) sa pomijane.
+    """
+    lekcje: Dict[tuple, Dict[str, Any]] = {}
+
+    for tydzien in tygodnie or []:
+        for dzien in tydzien or []:
+            for period in dzien or []:
+                przedmiot = (getattr(period, "subject", "") or "").strip()
+                if not przedmiot:
+                    continue
+
+                info = getattr(period, "info", None) or {}
+                opis = _opis_zmiany(info)
+                weekday = getattr(period, "weekday", "") or ""
+                data = getattr(period, "date", "") or ""
+                numer = getattr(period, "number", None)
+
+                lekcje[(data, numer)] = {
+                    "data": data,
+                    "dzien_tygodnia": DNI_TYGODNIA_PL.get(weekday, weekday),
+                    "numer": numer,
+                    "przedmiot": przedmiot,
+                    # Biblioteka sklada to pole dzielac tekst po "-", wiec w praktyce
+                    # bywa to sama sala albo nauczyciel z sala - nie rozbijamy tego dalej.
+                    "nauczyciel_sala": (
+                        getattr(period, "teacher_and_classroom", "") or ""
+                    ).strip(),
+                    "od": (getattr(period, "date_from", "") or "").strip(),
+                    "do": (getattr(period, "date_to", "") or "").strip(),
+                    "przerwa_od": getattr(period, "next_recess_from", None),
+                    "przerwa_do": getattr(period, "next_recess_to", None),
+                    "odwolana": _zawiera(opis, "odwol"),
+                    "zastepstwo": _zawiera(opis, "zastep"),
+                    "info": opis,
+                    "szczegoly": info,
+                }
+
+    return sorted(lekcje.values(), key=lambda l: (l["data"], l["numer"] or 0))
+
+
+def _polacz(data: str, godzina: str) -> Optional[datetime]:
+    """Zloz date (YYYY-MM-DD) i godzine (H:MM lub HH:MM) w datetime."""
+    if not data or not godzina:
+        return None
+    try:
+        return datetime.strptime(f"{data} {godzina}", "%Y-%m-%d %H:%M")
+    except ValueError:
+        return None
+
+
+def lekcje_dnia(plan: List[Dict[str, Any]], dzien: date) -> List[Dict[str, Any]]:
+    """Zwroc lekcje z podanego dnia."""
+    iso = dzien.strftime("%Y-%m-%d")
+    return [l for l in plan if l["data"] == iso]
+
+
+def pogrupuj_wg_dni(plan: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+    """Pogrupuj plan wedlug daty, zachowujac kolejnosc chronologiczna."""
+    dni: Dict[str, List[Dict[str, Any]]] = {}
+    for lekcja in plan:
+        dni.setdefault(lekcja["data"], []).append(lekcja)
+    return dni
+
+
+def nastepna_lekcja(
+    plan: List[Dict[str, Any]], teraz: datetime
+) -> Optional[Dict[str, Any]]:
+    """Znajdz trwajaca lub najblizsza przyszla lekcje.
+
+    Lekcje odwolane sa pomijane. Zwraca kopie slownika lekcji wzbogacona
+    o pola 'trwa_teraz' i 'za_minut' (0 dla lekcji trwajacej).
+    """
+    for lekcja in plan:
+        if lekcja.get("odwolana"):
+            continue
+
+        start = _polacz(lekcja["data"], lekcja["od"])
+        if start is None:
+            continue
+        koniec = _polacz(lekcja["data"], lekcja["do"])
+
+        # Bez poprawnej godziny konca przyjmujemy, ze lekcja minela wraz ze startem.
+        if (koniec or start) <= teraz:
+            continue
+
+        trwa = start <= teraz
+        pozostalo = 0 if trwa else int((start - teraz).total_seconds() // 60)
+        return {**lekcja, "trwa_teraz": trwa, "za_minut": pozostalo}
+
+    return None

--- a/custom_components/librus_apix/plan_lekcji.py
+++ b/custom_components/librus_apix/plan_lekcji.py
@@ -148,18 +148,27 @@ def _koniec_dnia(lekcje: List[Dict[str, Any]]) -> Optional[datetime]:
 
 
 def dni_do_wyswietlenia(
-    plan: List[Dict[str, Any]], teraz: datetime
+    plan: List[Dict[str, Any]],
+    teraz: datetime,
+    maks_dni: Optional[int] = None,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Dni, ktorych ostatnia lekcja jeszcze sie nie skonczyla.
 
     Dzien bez czytelnych godzin zostaje zachowany - lepiej pokazac za duzo
     niz ukryc dane, ktorych nie umiemy zinterpretowac.
+
+    Args:
+        maks_dni: ogranicz wynik do tylu pierwszych dni. Dzieki temu karta
+            pokazuje zawsze tyle samo dni, niezaleznie od tego, czy dzisiejsze
+            lekcje juz sie skonczyly.
     """
     wynik: Dict[str, List[Dict[str, Any]]] = {}
     for data, lekcje in pogrupuj_wg_dni(plan).items():
         koniec = _koniec_dnia(lekcje)
         if koniec is None or koniec > teraz:
             wynik[data] = lekcje
+            if maks_dni is not None and len(wynik) >= maks_dni:
+                break
     return wynik
 
 

--- a/custom_components/librus_apix/sensor.py
+++ b/custom_components/librus_apix/sensor.py
@@ -6,8 +6,10 @@ from typing import Any, Dict, List, Optional
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util import dt as dt_util
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -15,6 +17,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import DOMAIN, SCAN_INTERVAL
+from .plan_lekcji import lekcje_dnia, nastepna_lekcja, pogrupuj_wg_dni
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,6 +79,8 @@ async def async_setup_entry(
         LibrusWiadomosciSensor(coordinator, config_entry),
         LibrusZadaniaSensor(coordinator, config_entry),
         LibrusTerminarzSensor(coordinator, config_entry),
+        LibrusPlanLekcjiSensor(coordinator, config_entry),
+        LibrusNastepnaLekcjaSensor(coordinator, config_entry),
     ]
 
     # Tworz czujniki per przedmiot na podstawie pierwszego pobrania danych
@@ -93,6 +98,7 @@ EVENT_NOWA_WIADOMOSC = f"{DOMAIN}_nowa_wiadomosc"
 EVENT_NOWA_OCENA = f"{DOMAIN}_nowa_ocena"
 EVENT_NOWE_ZADANIE = f"{DOMAIN}_nowe_zadanie"
 EVENT_NOWE_ZDARZENIE = f"{DOMAIN}_nowe_zdarzenie"
+EVENT_ZMIANA_PLANU = f"{DOMAIN}_zmiana_planu"
 
 
 class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
@@ -105,6 +111,7 @@ class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
         self._seen_grade_ids: set = set()
         self._seen_homework_ids: set = set()
         self._seen_schedule_ids: set = set()
+        self._seen_plan_ids: set = set()
         self._first_run: bool = True
         super().__init__(
             hass,
@@ -124,6 +131,7 @@ class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
             messages = await self.client.async_get_messages(count=10)
             homework_raw = await self.client.async_get_homework()
             schedule_raw = await self.client.async_get_schedule()
+            plan_raw = await self.client.async_get_timetable()
 
             if grades is None:
                 # Zachowaj poprzednie dane o ocenach jesli dostepne, wiadomosci zaktualizuj jesli OK
@@ -150,6 +158,11 @@ class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
                         if schedule_raw is not None
                         else prev.get("terminarz", [])
                     ),
+                    "plan_lekcji": (
+                        plan_raw
+                        if plan_raw is not None
+                        else prev.get("plan_lekcji", [])
+                    ),
                 }
 
             # Grupuj oceny wg przedmiotu i oznacz nowe
@@ -170,6 +183,7 @@ class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
             wiadomosci = self._build_wiadomosci(messages)
             zadania = self._build_zadania(homework_raw)
             terminarz = schedule_raw if schedule_raw is not None else []
+            plan_lekcji = plan_raw if plan_raw is not None else []
 
             result = {
                 "student_info": student_info,
@@ -178,6 +192,7 @@ class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
                 "wiadomosci": wiadomosci,
                 "zadania": zadania,
                 "terminarz": terminarz,
+                "plan_lekcji": plan_lekcji,
                 "semestr_biezacy": current_sem,
             }
 
@@ -198,10 +213,16 @@ class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
                     self._seen_schedule_ids.add(
                         (zdarzenie["data"], zdarzenie["tytul"], zdarzenie["przedmiot"])
                     )
+                for lekcja in plan_lekcji:
+                    if lekcja["zastepstwo"] or lekcja["odwolana"]:
+                        self._seen_plan_ids.add(
+                            (lekcja["data"], lekcja["numer"], lekcja["info"])
+                        )
             else:
                 self._fire_events(wiadomosci, grades)
                 self._fire_homework_events(zadania)
                 self._fire_schedule_events(terminarz)
+                self._fire_plan_events(plan_lekcji)
 
             return result
 
@@ -259,6 +280,33 @@ class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
                         "godzina": zdarzenie["godzina"],
                     },
                 )
+
+    def _fire_plan_events(self, plan: List[Dict]) -> None:
+        """Wyslij zdarzenia HA dla nowych zastepstw i odwolanych lekcji."""
+        for lekcja in plan:
+            if not (lekcja["zastepstwo"] or lekcja["odwolana"]):
+                continue
+            plan_id = (lekcja["data"], lekcja["numer"], lekcja["info"])
+            if plan_id in self._seen_plan_ids:
+                continue
+            self._seen_plan_ids.add(plan_id)
+            _LOGGER.debug(
+                "Zmiana w planie: %s lekcja %s - %s",
+                lekcja["data"], lekcja["numer"], lekcja["info"],
+            )
+            self.hass.bus.fire(
+                EVENT_ZMIANA_PLANU,
+                {
+                    "data": lekcja["data"],
+                    "dzien_tygodnia": lekcja["dzien_tygodnia"],
+                    "numer": lekcja["numer"],
+                    "przedmiot": lekcja["przedmiot"],
+                    "od": lekcja["od"],
+                    "do": lekcja["do"],
+                    "rodzaj": "odwolana" if lekcja["odwolana"] else "zastepstwo",
+                    "info": lekcja["info"],
+                },
+            )
 
     def _build_wiadomosci(self, messages: Optional[List[Dict]]) -> List[Dict]:
         """Oznacz nowe wiadomosci i zwroc liste."""
@@ -620,6 +668,121 @@ class LibrusZadaniaSensor(CoordinatorEntity, SensorEntity):
             "zadania": zadania,
             "liczba_zadan": len(zadania),
             "kategorie": kategorie,
+        }
+
+
+class LibrusPlanLekcjiSensor(CoordinatorEntity, SensorEntity):
+    """Czujnik z planem lekcji (biezacy i nastepny tydzien)."""
+
+    def __init__(self, coordinator: LibrusDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
+        """Inicjalizacja."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._attr_has_entity_name = False
+        self._attr_name = "Plan lekcji"
+        self._attr_unique_id = f"{config_entry.entry_id}_plan_lekcji"
+        self._attr_icon = "mdi:timetable"
+
+    @property
+    def device_info(self) -> Dict[str, Any]:
+        return _device_info(self.coordinator, self._config_entry)
+
+    def _plan(self) -> List[Dict]:
+        return (self.coordinator.data or {}).get("plan_lekcji", [])
+
+    @property
+    def native_value(self) -> int:
+        """Liczba lekcji zaplanowanych na dzisiaj."""
+        return len(lekcje_dnia(self._plan(), dt_util.now().date()))
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        plan = self._plan()
+        dzis = dt_util.now().date()
+        dzisiaj = lekcje_dnia(plan, dzis)
+
+        # Ograniczamy atrybut do najblizszych 7 dni - pelne dwa tygodnie
+        # niepotrzebnie rozdymaja stan encji zapisywany przez recorder.
+        okno = [
+            l for l in plan
+            if dzis.strftime("%Y-%m-%d") <= l["data"] <= (dzis + timedelta(days=6)).strftime("%Y-%m-%d")
+        ]
+        zmiany = [l for l in okno if l["zastepstwo"] or l["odwolana"]]
+
+        return {
+            "dzisiaj": dzisiaj,
+            "jutro": lekcje_dnia(plan, dzis + timedelta(days=1)),
+            "tydzien": pogrupuj_wg_dni(okno),
+            "liczba_lekcji_dzisiaj": len(dzisiaj),
+            "pierwsza_lekcja": dzisiaj[0]["od"] if dzisiaj else None,
+            "ostatnia_lekcja": dzisiaj[-1]["do"] if dzisiaj else None,
+            "zmiany": zmiany,
+            "sa_zmiany": bool(zmiany),
+        }
+
+
+class LibrusNastepnaLekcjaSensor(CoordinatorEntity, SensorEntity):
+    """Czujnik z trwajaca lub najblizsza lekcja.
+
+    Koordynator odswieza dane co kilka godzin, wiec czujnik dodatkowo przelicza
+    swoj stan co minute - wylacznie lokalnie, bez odpytywania Librusa.
+    """
+
+    def __init__(self, coordinator: LibrusDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
+        """Inicjalizacja."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._attr_has_entity_name = False
+        self._attr_name = "Nastepna lekcja"
+        self._attr_unique_id = f"{config_entry.entry_id}_nastepna_lekcja"
+        self._attr_icon = "mdi:clock-start"
+
+    async def async_added_to_hass(self) -> None:
+        """Uruchom cykliczne przeliczanie stanu."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass, self._async_przelicz, timedelta(minutes=1)
+            )
+        )
+
+    @callback
+    def _async_przelicz(self, _now) -> None:
+        """Zapisz stan ponownie, aby odswiezyc odliczanie do lekcji."""
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> Dict[str, Any]:
+        return _device_info(self.coordinator, self._config_entry)
+
+    def _lekcja(self) -> Optional[Dict]:
+        plan = (self.coordinator.data or {}).get("plan_lekcji", [])
+        # Godziny z Librusa sa lokalne i bez strefy - porownujemy je z lokalnym
+        # czasem HA pozbawionym tzinfo.
+        teraz = dt_util.now().replace(tzinfo=None)
+        return nastepna_lekcja(plan, teraz)
+
+    @property
+    def native_value(self) -> Optional[str]:
+        lekcja = self._lekcja()
+        return lekcja["przedmiot"] if lekcja else None
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        lekcja = self._lekcja()
+        if not lekcja:
+            return {}
+        return {
+            "data": lekcja["data"],
+            "dzien_tygodnia": lekcja["dzien_tygodnia"],
+            "numer": lekcja["numer"],
+            "od": lekcja["od"],
+            "do": lekcja["do"],
+            "nauczyciel_sala": lekcja["nauczyciel_sala"],
+            "za_minut": lekcja["za_minut"],
+            "trwa_teraz": lekcja["trwa_teraz"],
+            "zastepstwo": lekcja["zastepstwo"],
+            "info": lekcja["info"],
         }
 
 

--- a/custom_components/librus_apix/sensor.py
+++ b/custom_components/librus_apix/sensor.py
@@ -16,7 +16,12 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DEFAULT_PLAN_DAYS, DOMAIN, SCAN_INTERVAL
+from .const import (
+    CONF_SCAN_INTERVAL_MINUTES,
+    DEFAULT_PLAN_DAYS,
+    DEFAULT_SCAN_INTERVAL_MINUTES,
+    DOMAIN,
+)
 from .plan_lekcji import (
     biezacy_dzien,
     dni_do_wyswietlenia,
@@ -26,6 +31,18 @@ from .plan_lekcji import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _interwal_odswiezania(config_entry: ConfigEntry) -> timedelta:
+    """Odczytaj czestotliwosc odpytywania Librusa z opcji integracji."""
+    minuty = config_entry.options.get(
+        CONF_SCAN_INTERVAL_MINUTES, DEFAULT_SCAN_INTERVAL_MINUTES
+    )
+    try:
+        minuty = int(minuty)
+    except (TypeError, ValueError):
+        minuty = DEFAULT_SCAN_INTERVAL_MINUTES
+    return timedelta(minutes=max(1, minuty))
 
 
 def _jest_nowa(date_str: str) -> bool:
@@ -75,7 +92,9 @@ async def async_setup_entry(
     """Konfiguracja platformy czujnikow Librus APIX."""
     client = hass.data[DOMAIN][config_entry.entry_id]
 
-    coordinator = LibrusDataUpdateCoordinator(hass, client)
+    coordinator = LibrusDataUpdateCoordinator(
+        hass, client, _interwal_odswiezania(config_entry)
+    )
     await coordinator.async_config_entry_first_refresh()
 
     entities: List[SensorEntity] = [
@@ -110,7 +129,12 @@ EVENT_ZMIANA_PLANU = f"{DOMAIN}_zmiana_planu"
 class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
     """Klasa zarzadzajaca pobieraniem danych z Librus."""
 
-    def __init__(self, hass: HomeAssistant, client: Any) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: Any,
+        update_interval: timedelta,
+    ) -> None:
         """Inicjalizacja koordynatora."""
         self.client = client
         self._seen_message_hrefs: set = set()
@@ -123,7 +147,7 @@ class LibrusDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=SCAN_INTERVAL,
+            update_interval=update_interval,
         )
 
     async def _async_update_data(self) -> Dict[str, Any]:

--- a/custom_components/librus_apix/sensor.py
+++ b/custom_components/librus_apix/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DOMAIN, SCAN_INTERVAL
+from .const import DEFAULT_PLAN_DAYS, DOMAIN, SCAN_INTERVAL
 from .plan_lekcji import (
     biezacy_dzien,
     dni_do_wyswietlenia,
@@ -743,11 +743,13 @@ class LibrusPlanLekcjiSensor(_OdswiezanieCominutowe, CoordinatorEntity, SensorEn
         teraz = self._teraz()
         dzis = teraz.date()
 
-        # Ograniczamy atrybut do najblizszych 7 dni - pelne dwa tygodnie
-        # niepotrzebnie rozdymaja stan encji zapisywany przez recorder.
+        # Osiem dni kalendarzowych zawsze zawiera co najmniej DEFAULT_PLAN_DAYS
+        # dni roboczych - takze wtedy, gdy dzisiejsze lekcje juz sie skonczyly
+        # i dzisiaj wypada z planu. Pelne dwa tygodnie niepotrzebnie rozdymaja
+        # stan encji zapisywany przez recorder.
         okno = [
             l for l in plan
-            if dzis.strftime("%Y-%m-%d") <= l["data"] <= (dzis + timedelta(days=6)).strftime("%Y-%m-%d")
+            if dzis.strftime("%Y-%m-%d") <= l["data"] <= (dzis + timedelta(days=7)).strftime("%Y-%m-%d")
         ]
         okno, wydarzenia_dnia, zadania_dnia = polacz_z_wydarzeniami(
             okno, dane.get("terminarz"), dane.get("zadania")
@@ -755,7 +757,7 @@ class LibrusPlanLekcjiSensor(_OdswiezanieCominutowe, CoordinatorEntity, SensorEn
 
         # Dzien znika, gdy skonczy sie jego ostatnia lekcja - ta sama zasada
         # rzadzi wyborem dnia do pokazania i zawartoscia planu tygodnia.
-        tydzien = dni_do_wyswietlenia(okno, teraz)
+        tydzien = dni_do_wyswietlenia(okno, teraz, DEFAULT_PLAN_DAYS)
         biezacy = biezacy_dzien(okno, teraz)
         dzisiaj = lekcje_dnia(okno, dzis)
         zmiany = [

--- a/custom_components/librus_apix/sensor.py
+++ b/custom_components/librus_apix/sensor.py
@@ -17,7 +17,13 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import DOMAIN, SCAN_INTERVAL
-from .plan_lekcji import lekcje_dnia, nastepna_lekcja, pogrupuj_wg_dni
+from .plan_lekcji import (
+    biezacy_dzien,
+    dni_do_wyswietlenia,
+    lekcje_dnia,
+    nastepna_lekcja,
+    polacz_z_wydarzeniami,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -365,6 +371,15 @@ def _device_info(coordinator: DataUpdateCoordinator, config_entry: ConfigEntry) 
     }
 
 
+def _lekcja_do_atrybutu(lekcja: Dict[str, Any]) -> Dict[str, Any]:
+    """Okrojona lekcja do atrybutu encji.
+
+    Pomijamy godziny przerw - nie uzywa ich zadna karta, a przy pelnym tygodniu
+    to setki bajtow zblizajacych stan do limitu recordera (16 KB).
+    """
+    return {k: v for k, v in lekcja.items() if k not in ("przerwa_od", "przerwa_do")}
+
+
 class LibrusUczenSensor(CoordinatorEntity, SensorEntity):
     """Czujnik z informacjami o uczniu."""
 
@@ -671,7 +686,33 @@ class LibrusZadaniaSensor(CoordinatorEntity, SensorEntity):
         }
 
 
-class LibrusPlanLekcjiSensor(CoordinatorEntity, SensorEntity):
+class _OdswiezanieCominutowe:
+    """Przelicza stan encji co minute, lokalnie i bez odpytywania Librusa.
+
+    Koordynator odswieza dane co kilka godzin, a oba czujniki planu zaleza od
+    biezacego czasu (trwajaca lekcja, dzien do pokazania). Home Assistant nie
+    zapisuje stanu, gdy nic sie nie zmienilo, wiec jest to tanie.
+    """
+
+    async def async_added_to_hass(self) -> None:
+        """Uruchom cykliczne przeliczanie stanu."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass, self._async_przelicz, timedelta(minutes=1)
+            )
+        )
+
+    @callback
+    def _async_przelicz(self, _now) -> None:
+        self.async_write_ha_state()
+
+    def _teraz(self) -> datetime:
+        """Lokalny czas HA bez strefy - godziny z Librusa tez sa lokalne."""
+        return dt_util.now().replace(tzinfo=None)
+
+
+class LibrusPlanLekcjiSensor(_OdswiezanieCominutowe, CoordinatorEntity, SensorEntity):
     """Czujnik z planem lekcji (biezacy i nastepny tydzien)."""
 
     def __init__(self, coordinator: LibrusDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
@@ -693,13 +734,14 @@ class LibrusPlanLekcjiSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> int:
         """Liczba lekcji zaplanowanych na dzisiaj."""
-        return len(lekcje_dnia(self._plan(), dt_util.now().date()))
+        return len(lekcje_dnia(self._plan(), self._teraz().date()))
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
+        dane = self.coordinator.data or {}
         plan = self._plan()
-        dzis = dt_util.now().date()
-        dzisiaj = lekcje_dnia(plan, dzis)
+        teraz = self._teraz()
+        dzis = teraz.date()
 
         # Ograniczamy atrybut do najblizszych 7 dni - pelne dwa tygodnie
         # niepotrzebnie rozdymaja stan encji zapisywany przez recorder.
@@ -707,12 +749,32 @@ class LibrusPlanLekcjiSensor(CoordinatorEntity, SensorEntity):
             l for l in plan
             if dzis.strftime("%Y-%m-%d") <= l["data"] <= (dzis + timedelta(days=6)).strftime("%Y-%m-%d")
         ]
-        zmiany = [l for l in okno if l["zastepstwo"] or l["odwolana"]]
+        okno, wydarzenia_dnia, zadania_dnia = polacz_z_wydarzeniami(
+            okno, dane.get("terminarz"), dane.get("zadania")
+        )
 
+        # Dzien znika, gdy skonczy sie jego ostatnia lekcja - ta sama zasada
+        # rzadzi wyborem dnia do pokazania i zawartoscia planu tygodnia.
+        tydzien = dni_do_wyswietlenia(okno, teraz)
+        biezacy = biezacy_dzien(okno, teraz)
+        dzisiaj = lekcje_dnia(okno, dzis)
+        zmiany = [
+            _lekcja_do_atrybutu(l) for lekcje in tydzien.values() for l in lekcje
+            if l["zastepstwo"] or l["odwolana"]
+        ]
+
+        # Recorder w HA odrzuca stan powyzej 16 KB atrybutow, dlatego lekcje
+        # wystawiamy tylko raz - w "tydzien". Dzien do pokazania wskazuje
+        # "biezacy_dzien_data", czyli klucz w tym samym slowniku.
         return {
-            "dzisiaj": dzisiaj,
-            "jutro": lekcje_dnia(plan, dzis + timedelta(days=1)),
-            "tydzien": pogrupuj_wg_dni(okno),
+            "tydzien": {
+                data: [_lekcja_do_atrybutu(l) for l in lekcje]
+                for data, lekcje in tydzien.items()
+            },
+            "biezacy_dzien_data": biezacy[0]["data"] if biezacy else None,
+            "biezacy_dzien_nazwa": biezacy[0]["dzien_tygodnia"] if biezacy else None,
+            "wydarzenia_dnia": wydarzenia_dnia,
+            "zadania_dnia": zadania_dnia,
             "liczba_lekcji_dzisiaj": len(dzisiaj),
             "pierwsza_lekcja": dzisiaj[0]["od"] if dzisiaj else None,
             "ostatnia_lekcja": dzisiaj[-1]["do"] if dzisiaj else None,
@@ -721,12 +783,8 @@ class LibrusPlanLekcjiSensor(CoordinatorEntity, SensorEntity):
         }
 
 
-class LibrusNastepnaLekcjaSensor(CoordinatorEntity, SensorEntity):
-    """Czujnik z trwajaca lub najblizsza lekcja.
-
-    Koordynator odswieza dane co kilka godzin, wiec czujnik dodatkowo przelicza
-    swoj stan co minute - wylacznie lokalnie, bez odpytywania Librusa.
-    """
+class LibrusNastepnaLekcjaSensor(_OdswiezanieCominutowe, CoordinatorEntity, SensorEntity):
+    """Czujnik z trwajaca lub najblizsza lekcja."""
 
     def __init__(self, coordinator: LibrusDataUpdateCoordinator, config_entry: ConfigEntry) -> None:
         """Inicjalizacja."""
@@ -737,30 +795,13 @@ class LibrusNastepnaLekcjaSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{config_entry.entry_id}_nastepna_lekcja"
         self._attr_icon = "mdi:clock-start"
 
-    async def async_added_to_hass(self) -> None:
-        """Uruchom cykliczne przeliczanie stanu."""
-        await super().async_added_to_hass()
-        self.async_on_remove(
-            async_track_time_interval(
-                self.hass, self._async_przelicz, timedelta(minutes=1)
-            )
-        )
-
-    @callback
-    def _async_przelicz(self, _now) -> None:
-        """Zapisz stan ponownie, aby odswiezyc odliczanie do lekcji."""
-        self.async_write_ha_state()
-
     @property
     def device_info(self) -> Dict[str, Any]:
         return _device_info(self.coordinator, self._config_entry)
 
     def _lekcja(self) -> Optional[Dict]:
         plan = (self.coordinator.data or {}).get("plan_lekcji", [])
-        # Godziny z Librusa sa lokalne i bez strefy - porownujemy je z lokalnym
-        # czasem HA pozbawionym tzinfo.
-        teraz = dt_util.now().replace(tzinfo=None)
-        return nastepna_lekcja(plan, teraz)
+        return nastepna_lekcja(plan, self._teraz())
 
     @property
     def native_value(self) -> Optional[str]:

--- a/custom_components/librus_apix/strings.json
+++ b/custom_components/librus_apix/strings.json
@@ -17,5 +17,16 @@
     "abort": {
       "already_configured": "Device is already configured"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opcje Librus APIX",
+        "description": "Jak często pobierać dane z Librusa. Jedno odświeżenie to 8 zapytań (oceny, wiadomości, zadania, dane ucznia, terminarz i plan lekcji), więc przy 120 minutach wychodzi około 96 zapytań na dobę. Sensory planu przeliczają się co minutę lokalnie i nie generują dodatkowego ruchu.",
+        "data": {
+          "scan_interval_minutes": "Częstotliwość odświeżania (minuty)"
+        }
+      }
+    }
   }
 }

--- a/examples/dashboard-plan-lekcji.yaml
+++ b/examples/dashboard-plan-lekcji.yaml
@@ -1,0 +1,185 @@
+# Gotowy dashboard: plan lekcji Librus
+#
+# JAK UZYC
+#   1. Zamien w calym pliku "sensor.librus_imie_nazwisko" na swoja encje.
+#      Znajdziesz ja w Narzedzia deweloperskie -> Stany, szukajac "plan_lekcji".
+#      Encje biora nazwe od imienia i nazwiska ucznia, np.
+#      sensor.librus_jan_kowalski_plan_lekcji
+#   2. Ustawienia -> Dashboardy -> Dodaj dashboard -> Nowy dashboard od zera
+#   3. Otworz go, menu (trzy kropki) -> Edytuj -> znowu trzy kropki ->
+#      Edytor nieprzetworzonej konfiguracji (Raw configuration editor)
+#   4. Wklej cala zawartosc tego pliku i zapisz
+#
+# WYMAGA
+#   Mushroom Cards (HACS -> Frontend -> "Mushroom"). Bez tego karty
+#   custom:mushroom-* pokaza blad "Custom element doesn't exist".
+#
+# UKLAD
+#   Karty sa opakowane w jeden vertical-stack, zeby wymusic jedna kolumne.
+#   max_columns w widoku nie zadziala - domyslny widok masonry ignoruje
+#   konfiguracje i liczy kolumny wylacznie z szerokosci ekranu.
+views:
+- title: Plan lekcji
+  path: plan-lekcji
+  icon: mdi:timetable
+  cards:
+  - type: vertical-stack
+    cards:
+    - type: vertical-stack
+      cards:
+      - type: custom:mushroom-title-card
+        title: 📅 Nadchodzące wydarzenia
+        subtitle: '{% set z = state_attr(''sensor.librus_imie_nazwisko_terminarz'', ''zdarzenia'') or [] %} {% set do = (now() + timedelta(days=28)).strftime(''%Y-%m-%d'') %} {% set n = z | selectattr(''data'', ''le'', do) | list | count %} {% set r = n % 10 %}{% set s = n % 100 %} {% if n == 0 %}Najbliższe 4 tygodnie bez wydarzeń{% else %}{{ n }} {% if n == 1 %}wydarzenie{% elif r in [2, 3, 4] and s not in [12, 13, 14] %}wydarzenia{% else %}wydarzeń{% endif %} w najbliższych 4 tygodniach{% endif %}'
+      - type: markdown
+        content: '{%- set wszystkie = state_attr(''sensor.librus_imie_nazwisko_terminarz'', ''zdarzenia'') or [] %}
+
+          {%- set do = (now() + timedelta(days=28)).strftime(''%Y-%m-%d'') %}
+
+          {%- set zdarzenia = wszystkie | selectattr(''data'', ''le'', do) | list %}
+
+          {%- set testy = [''sprawdzian'', ''kartkówka'', ''klasówka'', ''praca klasowa''] %}
+
+          {%- if zdarzenia %}
+
+          | Data | Dzień | Wydarzenie | Przedmiot | Szczegóły |
+
+          |------|-------|------------|-----------|-----------|
+
+          {%- for z in zdarzenia %}
+
+          {%- set k = ''#e53935'' if z.tytul | lower in testy else '''' %}
+
+          {%- set opis = z.szczegoly.Opis if z.szczegoly.Opis not in [none, '''', ''unknown''] else '''' %}
+
+          | {% if k %}<font color="{{ k }}">**{% endif %}{{ z.data }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ z.tydzien }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ z.tytul }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ z.przedmiot }}{% if k %}**</font>{% endif %} | {{ opis }}{% if z.godzina not in ['''', ''unknown'', none] %}{% if opis %} · {% endif %}{{ z.godzina }}{% endif %} |
+
+          {%- endfor %}
+
+          {%- else %}
+
+          Brak wydarzeń w najbliższych 4 tygodniach.
+
+          {%- endif %}'
+    - type: vertical-stack
+      cards:
+      - type: custom:mushroom-title-card
+        title: 📚 Plan lekcji
+        subtitle: '{% set p = ''sensor.librus_imie_nazwisko_plan_lekcji'' %} {% set dt = state_attr(p, ''biezacy_dzien_data'') %} {% set tydzien = state_attr(p, ''tydzien'') %} {% set d = tydzien[dt] if dt in tydzien else [] %} {% if not d %}Brak nadchodzących lekcji 🎉{% else %}{% if dt == now().strftime(''%Y-%m-%d'') %}Dziś{% else %}{{ state_attr(p, ''biezacy_dzien_nazwa'') }} {{ state_attr(p, ''biezacy_dzien_data'') }}{% endif %} · {{ d | count }} lekcji · {{ d[0].od }}–{{ d[-1].do }}{% endif %}'
+      - type: custom:mushroom-template-card
+        primary: "{% set s = 'sensor.librus_imie_nazwisko_nastepna_lekcja' %} {% if states(s) in ['unknown', 'unavailable', 'None'] %}\n  Brak zaplanowanych lekcji\n{% else %}\n  {{ states(s) }}\n{% endif %}"
+        secondary: "{% set s = 'sensor.librus_imie_nazwisko_nastepna_lekcja' %} {% if states(s) in ['unknown', 'unavailable', 'None'] %}\n  —\n{% elif state_attr(s, 'trwa_teraz') %}\n  Trwa do {{ state_attr(s, 'do') }} · {{ state_attr(s, 'nauczyciel_sala') }}\n{% elif state_attr(s, 'data') != now().strftime('%Y-%m-%d') %}\n  {{ state_attr(s, 'dzien_tygodnia') }} {{ state_attr(s, 'od') }} · {{ state_attr(s, 'nauczyciel_sala') }}\n{% else %}\n  {{ state_attr(s, 'numer') }}. lekcja · {{ state_attr(s, 'od') }} ·\n  za {{ state_attr(s, 'za_minut') }} min\n{% endif %}"
+        icon: '{% set s = ''sensor.librus_imie_nazwisko_nastepna_lekcja'' %} {% if state_attr(s, ''trwa_teraz'') %}mdi:school {% elif state_attr(s, ''data'') != now().strftime(''%Y-%m-%d'') %}mdi:calendar-clock {% else %}mdi:clock-start{% endif %}'
+        icon_color: '{% set s = ''sensor.librus_imie_nazwisko_nastepna_lekcja'' %} {% if state_attr(s, ''zastepstwo'') %}orange {% elif state_attr(s, ''trwa_teraz'') %}green {% else %}blue{% endif %}'
+        badge_icon: "{% if state_attr('sensor.librus_imie_nazwisko_nastepna_lekcja', 'zastepstwo') %}\n  mdi:account-switch\n{% endif %}"
+        badge_color: orange
+      - type: conditional
+        conditions:
+        - condition: state
+          entity: sensor.librus_imie_nazwisko_plan_lekcji
+          attribute: sa_zmiany
+          state: true
+        card:
+          type: custom:mushroom-template-card
+          primary: Zmiany w planie
+          secondary: '{% set z = state_attr(''sensor.librus_imie_nazwisko_plan_lekcji'', ''zmiany'') %} {{ z | count }} zmian w najbliższym tygodniu'
+          icon: mdi:calendar-alert
+          icon_color: orange
+      - type: markdown
+        content: '{%- set p = ''sensor.librus_imie_nazwisko_plan_lekcji'' %}
+
+          {%- set d = state_attr(p, ''biezacy_dzien_data'') %}
+
+          {%- set tydzien = state_attr(p, ''tydzien'') %}
+
+          {%- set lekcje = tydzien[d] if d in tydzien else [] %}
+
+          {%- set wd = state_attr(p, ''wydarzenia_dnia'') %}
+
+          {%- set zd = state_attr(p, ''zadania_dnia'') %}
+
+          {%- if lekcje %}
+
+          **{{ state_attr(p, ''biezacy_dzien_nazwa'') }}, {{ d }}**
+
+          {%- for w in (wd[d] if d in wd else []) %}
+
+
+          📌 {{ w.przedmiot }}{% if w.godzina not in ['''', ''unknown''] %} · {{ w.godzina }}{% endif %}
+
+          {%- endfor %}
+
+          {%- for z in (zd[d] if d in zd else []) %}
+
+
+          📚 {{ z.przedmiot }} · {{ z.kategoria }}
+
+          {%- endfor %}
+
+
+          | # | Godzina | Przedmiot | Sala |
+
+          |---|---------|-----------|------|
+
+          {%- for l in lekcje %}
+
+          {%- set k = ''#e53935'' if l.wydarzenia else (''#f9a825'' if l.zadania else '''') %}
+
+          | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.numer }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.od }}–{{ l.do }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo and not k %}**{{ l.przedmiot }}** ⚠️{% elif l.zastepstwo %}{{ l.przedmiot }} ⚠️{% else %}{{ l.przedmiot }}{% endif %}{% for w in l.wydarzenia %} 📝 {{ w.tytul }}{% endfor %}{% for z in l.zadania %} 📚 {{ z.kategoria }}{% endfor %}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.nauczyciel_sala }}{% if k %}**</font>{% endif %} |
+
+          {%- endfor %}
+
+          {%- else %}
+
+          Brak nadchodzących lekcji.
+
+          {%- endif %}'
+    - type: markdown
+      title: 🗓️ Plan tygodnia
+      content: '{%- set p = ''sensor.librus_imie_nazwisko_plan_lekcji'' %}
+
+        {%- set tydzien = state_attr(p, ''tydzien'') %}
+
+        {%- set wd = state_attr(p, ''wydarzenia_dnia'') %}
+
+        {%- set zd = state_attr(p, ''zadania_dnia'') %}
+
+        {%- if tydzien %}
+
+        {%- for data, lekcje in tydzien.items() %}
+
+        **{{ lekcje[0].dzien_tygodnia }} {{ data }}**
+
+        {%- for w in (wd[data] if data in wd else []) %}
+
+
+        📌 {{ w.przedmiot }}{% if w.godzina not in ['''', ''unknown''] %} · {{ w.godzina }}{% endif %}
+
+        {%- endfor %}
+
+        {%- for z in (zd[data] if data in zd else []) %}
+
+
+        📚 {{ z.przedmiot }} · {{ z.kategoria }}
+
+        {%- endfor %}
+
+
+        | # | Godzina | Przedmiot | Sala |
+
+        |---|---------|-----------|------|
+
+        {%- for l in lekcje %}
+
+        {%- set k = ''#e53935'' if l.wydarzenia else (''#f9a825'' if l.zadania else '''') %}
+
+        | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.numer }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.od }}–{{ l.do }}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{% if l.odwolana %}~~{{ l.przedmiot }}~~{% elif l.zastepstwo and not k %}**{{ l.przedmiot }}** ⚠️{% elif l.zastepstwo %}{{ l.przedmiot }} ⚠️{% else %}{{ l.przedmiot }}{% endif %}{% for w in l.wydarzenia %} 📝 {{ w.tytul }}{% endfor %}{% for z in l.zadania %} 📚 {{ z.kategoria }}{% endfor %}{% if k %}**</font>{% endif %} | {% if k %}<font color="{{ k }}">**{% endif %}{{ l.nauczyciel_sala }}{% if k %}**</font>{% endif %} |
+
+        {%- endfor %}
+
+        {% endfor %}
+
+        {%- else %}
+
+        Brak danych o planie lekcji.
+
+        {%- endif %}'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,7 +22,7 @@ def _lekcja(numer, przedmiot, od, do, dzien=None, zastepstwo=False, odwolana=Fal
     dzien = dzien or date.today()
     return {
         "data": dzien.strftime("%Y-%m-%d"),
-        "dzien_tygodnia": "Poniedzialek",
+        "dzien_tygodnia": "Poniedziałek",
         "numer": numer,
         "przedmiot": przedmiot,
         "nauczyciel_sala": "12",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -259,3 +259,82 @@ async def test_plan_tygodnia_zawsze_pokazuje_piec_dni(
     assert dzis.strftime("%Y-%m-%d") not in tydzien
     assert list(tydzien)[0] == (dzis + timedelta(days=1)).strftime("%Y-%m-%d")
     assert list(tydzien)[-1] == (dzis + timedelta(days=5)).strftime("%Y-%m-%d")
+
+
+async def test_domyslny_interwal_odswiezania(
+    hass: HomeAssistant, mock_config_entry, mock_librus_client
+):
+    """Bez opcji koordynator odswieza sie co 2 godziny."""
+    from custom_components.librus_apix.sensor import _interwal_odswiezania
+
+    await _setup(hass, mock_config_entry, mock_librus_client)
+
+    assert _interwal_odswiezania(mock_config_entry) == timedelta(hours=2)
+
+
+async def test_interwal_z_opcji_integracji(
+    hass: HomeAssistant, mock_config_entry, mock_librus_client
+):
+    """Opcja z UI zmienia czestotliwosc odpytywania Librusa."""
+    from custom_components.librus_apix.sensor import _interwal_odswiezania
+
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, options={"scan_interval_minutes": 30}
+    )
+
+    assert _interwal_odswiezania(mock_config_entry) == timedelta(minutes=30)
+
+
+async def test_interwal_zapisany_jako_float(
+    hass: HomeAssistant, mock_config_entry
+):
+    """NumberSelector zapisuje liczbe zmiennoprzecinkowa (45.0), nie int."""
+    from custom_components.librus_apix.sensor import _interwal_odswiezania
+
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, options={"scan_interval_minutes": 45.0}
+    )
+
+    assert _interwal_odswiezania(mock_config_entry) == timedelta(minutes=45)
+
+
+async def test_interwal_odporny_na_smieciowa_wartosc(
+    hass: HomeAssistant, mock_config_entry
+):
+    """Nieparsowalna wartosc nie wywala integracji - wracamy do domyslnej."""
+    from custom_components.librus_apix.sensor import _interwal_odswiezania
+
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, options={"scan_interval_minutes": "abc"}
+    )
+
+    assert _interwal_odswiezania(mock_config_entry) == timedelta(hours=2)
+
+
+async def test_koordynator_uzywa_interwalu_z_opcji(
+    hass: HomeAssistant, mock_config_entry, mock_librus_client
+):
+    """Interwal z opcji trafia do koordynatora przy konfiguracji platformy."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, options={"scan_interval_minutes": 45}
+    )
+    with patch("custom_components.librus_apix.LibrusApiClient", return_value=mock_librus_client):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Koordynator jest wspoldzielony przez wszystkie encje platformy.
+    from homeassistant.helpers import entity_registry as er
+    rejestr = er.async_get(hass)
+    encje = er.async_entries_for_config_entry(rejestr, mock_config_entry.entry_id)
+    assert encje, "brak encji - platforma sie nie skonfigurowala"
+
+    komponent = hass.data["entity_components"]["sensor"]
+    encja = next(
+        e for e in komponent.entities
+        if e.entity_id.endswith("_plan_lekcji")
+    )
+    assert encja.coordinator.update_interval == timedelta(minutes=45)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -111,14 +111,23 @@ async def test_unload_entry(hass: HomeAssistant, mock_config_entry, mock_librus_
 
 async def test_plan_lekcji_sensor(hass: HomeAssistant, mock_config_entry, mock_librus_client):
     """Czujnik planu lekcji wystawia dzisiejsze lekcje i wykryte zmiany."""
+    # Ostatnia lekcja konczy sie o 23:59, wiec dzien jest "biezacy" niezaleznie
+    # od tego, o ktorej uruchomiono testy.
+    mock_librus_client.async_get_timetable.return_value = [
+        _lekcja(1, "Matematyka", "00:00", "00:45"),
+        _lekcja(2, "Fizyka", "23:10", "23:59", zastepstwo=True),
+        _lekcja(1, "Historia", "08:00", "08:45", dzien=date.today() + timedelta(days=1)),
+    ]
+
     await _setup(hass, mock_config_entry, mock_librus_client)
 
     stan = hass.states.get("sensor.librus_jan_kowalski_plan_lekcji")
     assert stan is not None
     assert stan.state == "2"
-    assert stan.attributes["pierwsza_lekcja"] == "08:00"
-    assert stan.attributes["ostatnia_lekcja"] == "09:45"
-    assert [l["przedmiot"] for l in stan.attributes["jutro"]] == ["Historia"]
+    assert stan.attributes["pierwsza_lekcja"] == "00:00"
+    assert stan.attributes["ostatnia_lekcja"] == "23:59"
+    jutro = (date.today() + timedelta(days=1)).strftime("%Y-%m-%d")
+    assert [l["przedmiot"] for l in stan.attributes["tydzien"][jutro]] == ["Historia"]
     assert stan.attributes["sa_zmiany"] is True
     assert [l["przedmiot"] for l in stan.attributes["zmiany"]] == ["Fizyka"]
 
@@ -137,3 +146,91 @@ async def test_nastepna_lekcja_sensor(hass: HomeAssistant, mock_config_entry, mo
     assert stan.state == "Fizyka"
     assert stan.attributes["numer"] == 2
     assert stan.attributes["od"] == "23:58"
+
+
+async def test_plan_lekcji_przeskakuje_na_kolejny_dzien(
+    hass: HomeAssistant, mock_config_entry, mock_librus_client
+):
+    """Po ostatniej lekcji dnia czujnik pokazuje plan nastepnego dnia."""
+    jutro = date.today() + timedelta(days=1)
+    mock_librus_client.async_get_timetable.return_value = [
+        # Dzisiejsze lekcje sa juz po czasie (koncza sie o 00:01).
+        _lekcja(1, "Matematyka", "00:00", "00:01"),
+        _lekcja(1, "Historia", "08:00", "08:45", dzien=jutro),
+        _lekcja(2, "Chemia", "09:00", "09:45", dzien=jutro),
+    ]
+
+    await _setup(hass, mock_config_entry, mock_librus_client)
+
+    stan = hass.states.get("sensor.librus_jan_kowalski_plan_lekcji")
+    assert [l["przedmiot"] for l in stan.attributes["tydzien"][stan.attributes["biezacy_dzien_data"]]] == [
+        "Historia",
+        "Chemia",
+    ]
+    assert stan.attributes["biezacy_dzien_data"] == jutro.strftime("%Y-%m-%d")
+    assert stan.attributes["biezacy_dzien_nazwa"]
+
+    # Zakonczony dzien znika rowniez z planu tygodnia.
+    assert list(stan.attributes["tydzien"]) == [jutro.strftime("%Y-%m-%d")]
+
+    # Liczniki nadal opisuja doslownie dzisiaj.
+    assert stan.attributes["liczba_lekcji_dzisiaj"] == 1
+
+
+async def test_plan_lekcji_trzyma_sie_dzis_w_trakcie_zajec(
+    hass: HomeAssistant, mock_config_entry, mock_librus_client
+):
+    """Dopoki trwa ostatnia lekcja, pokazywany jest biezacy dzien."""
+    mock_librus_client.async_get_timetable.return_value = [
+        _lekcja(1, "Matematyka", "00:00", "23:59"),
+        _lekcja(1, "Historia", "08:00", "08:45", dzien=date.today() + timedelta(days=1)),
+    ]
+
+    await _setup(hass, mock_config_entry, mock_librus_client)
+
+    stan = hass.states.get("sensor.librus_jan_kowalski_plan_lekcji")
+    assert [l["przedmiot"] for l in stan.attributes["tydzien"][stan.attributes["biezacy_dzien_data"]]] == ["Matematyka"]
+    assert stan.attributes["biezacy_dzien_data"] == date.today().strftime("%Y-%m-%d")
+
+
+async def test_plan_lekcji_zaznacza_wydarzenia_i_zadania(
+    hass: HomeAssistant, mock_config_entry, mock_librus_client
+):
+    """Kartkowka trafia na swoja lekcje, wywiadowka do wydarzen calodniowych."""
+    dzis = date.today().strftime("%Y-%m-%d")
+    mock_librus_client.async_get_timetable.return_value = [
+        _lekcja(1, "matematyka", "00:00", "00:45"),
+        _lekcja(4, "fizyka", "23:10", "23:59"),
+    ]
+    mock_librus_client.async_get_schedule.return_value = [
+        {
+            "data": dzis, "tydzien": "Wednesday", "tytul": "kartkówka",
+            "przedmiot": "fizyka", "godzina": "unknown", "numer_lekcji": 4,
+            "szczegoly": {"Nauczyciel": "Anna Nowak", "Opis": "wielkości fizyczne"},
+            "href": "",
+        },
+        {
+            "data": dzis, "tydzien": "Wednesday", "tytul": "godz.: 17:00",
+            "przedmiot": "Wywiadówka: zebranie rodziców", "godzina": "17:00",
+            "numer_lekcji": "unknown", "szczegoly": {}, "href": "",
+        },
+    ]
+    mock_librus_client.async_get_homework.return_value = [
+        SimpleNamespace(
+            subject="matematyka", category="Praca domowa", teacher="Danuta Kowalska",
+            lesson="", task_date=dzis, completion_date=dzis, href="",
+        )
+    ]
+
+    await _setup(hass, mock_config_entry, mock_librus_client)
+
+    stan = hass.states.get("sensor.librus_jan_kowalski_plan_lekcji")
+    lekcje = {l["przedmiot"]: l for l in stan.attributes["tydzien"][stan.attributes["biezacy_dzien_data"]]}
+
+    assert [w["tytul"] for w in lekcje["fizyka"]["wydarzenia"]] == ["kartkówka"]
+    assert lekcje["fizyka"]["wydarzenia"][0]["opis"] == "wielkości fizyczne"
+    assert [z["kategoria"] for z in lekcje["matematyka"]["zadania"]] == ["Praca domowa"]
+    assert lekcje["matematyka"]["wydarzenia"] == []
+
+    calodniowe = stan.attributes["wydarzenia_dnia"][dzis]
+    assert [w["przedmiot"] for w in calodniowe] == ["Wywiadówka: zebranie rodziców"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -234,3 +234,28 @@ async def test_plan_lekcji_zaznacza_wydarzenia_i_zadania(
 
     calodniowe = stan.attributes["wydarzenia_dnia"][dzis]
     assert [w["przedmiot"] for w in calodniowe] == ["Wywiadówka: zebranie rodziców"]
+
+
+async def test_plan_tygodnia_zawsze_pokazuje_piec_dni(
+    hass: HomeAssistant, mock_config_entry, mock_librus_client
+):
+    """Po ostatniej lekcji dnia w planie nadal jest piec dni lekcyjnych."""
+    dzis = date.today()
+    # Dzisiejsze lekcje juz sie skonczyly, kolejne szesc dni ma zajecia.
+    plan = [_lekcja(1, "matematyka", "00:00", "00:01")]
+    for i in range(1, 7):
+        plan.append(
+            _lekcja(1, f"przedmiot{i}", "08:00", "08:45", dzien=dzis + timedelta(days=i))
+        )
+    mock_librus_client.async_get_timetable.return_value = plan
+
+    await _setup(hass, mock_config_entry, mock_librus_client)
+
+    stan = hass.states.get("sensor.librus_jan_kowalski_plan_lekcji")
+    tydzien = stan.attributes["tydzien"]
+
+    assert len(tydzien) == 5, f"oczekiwano 5 dni, jest {len(tydzien)}: {list(tydzien)}"
+    # Zakonczone dzis nie zajmuje miejsca w limicie.
+    assert dzis.strftime("%Y-%m-%d") not in tydzien
+    assert list(tydzien)[0] == (dzis + timedelta(days=1)).strftime("%Y-%m-%d")
+    assert list(tydzien)[-1] == (dzis + timedelta(days=5)).strftime("%Y-%m-%d")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,23 +1,49 @@
 """Test the Librus APIX integration."""
 
+from datetime import date, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
-from unittest.mock import AsyncMock, patch, MagicMock
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.librus_apix.const import DOMAIN
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Wlacz ladowanie custom_components w testach."""
+    return
+
+
+def _lekcja(numer, przedmiot, od, do, dzien=None, zastepstwo=False, odwolana=False):
+    """Zbuduj wpis planu lekcji w formacie zwracanym przez async_get_timetable."""
+    dzien = dzien or date.today()
+    return {
+        "data": dzien.strftime("%Y-%m-%d"),
+        "dzien_tygodnia": "Poniedzialek",
+        "numer": numer,
+        "przedmiot": przedmiot,
+        "nauczyciel_sala": "12",
+        "od": od,
+        "do": do,
+        "przerwa_od": None,
+        "przerwa_do": None,
+        "odwolana": odwolana,
+        "zastepstwo": zastepstwo,
+        "info": "Zastepstwo" if zastepstwo else ("Lekcja odwolana" if odwolana else ""),
+        "szczegoly": {},
+    }
 
 
 @pytest.fixture
 def mock_config_entry():
     """Return a mock config entry."""
-    return ConfigEntry(
-        version=1,
+    return MockConfigEntry(
         domain=DOMAIN,
         title="Test Librus",
         data={"username": "test_user", "password": "test_password"},
-        source="user",
-        entry_id="test_entry_id"
     )
 
 
@@ -26,39 +52,88 @@ def mock_librus_client():
     """Return a mock Librus client."""
     client = MagicMock()
     client.async_authenticate = AsyncMock(return_value=True)
+    client.async_get_student_information = AsyncMock(
+        return_value=SimpleNamespace(
+            name="Jan Kowalski",
+            class_name="8A",
+            number=7,
+            tutor="Anna Nowak",
+            school="SP nr 1",
+            lucky_number=13,
+        )
+    )
     client.async_get_grades = AsyncMock(return_value=[
         {
-            'subject': 'Mathematyka',
-            'grade': '5',
-            'date': '2025-01-01',
-            'category': 'Test',
-            'teacher': 'Jan Kowalski',
-            'type': 'numeric'
+            "subject": "Matematyka",
+            "grade": "5",
+            "date": "2025-01-01",
+            "category": "Test",
+            "teacher": "Jan Kowalski",
+            "semester": 1,
+            "type": "numeric",
         }
     ])
     client.async_get_messages = AsyncMock(return_value=[])
+    client.async_get_homework = AsyncMock(return_value=[])
+    client.async_get_schedule = AsyncMock(return_value=[])
+    client.async_get_timetable = AsyncMock(return_value=[
+        _lekcja(1, "Matematyka", "08:00", "08:45"),
+        _lekcja(2, "Fizyka", "09:00", "09:45", zastepstwo=True),
+        _lekcja(1, "Historia", "08:00", "08:45", dzien=date.today() + timedelta(days=1)),
+    ])
     return client
+
+
+async def _setup(hass: HomeAssistant, entry, client) -> None:
+    """Skonfiguruj integracje z zamockowanym klientem."""
+    entry.add_to_hass(hass)
+    with patch("custom_components.librus_apix.LibrusApiClient", return_value=client):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
 
 async def test_setup_entry(hass: HomeAssistant, mock_config_entry, mock_librus_client):
     """Test the setup entry."""
-    with patch(
-        "custom_components.librus_apix.LibrusApiClient",
-        return_value=mock_librus_client
-    ):
-        result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        assert result is True
+    await _setup(hass, mock_config_entry, mock_librus_client)
+
+    assert mock_config_entry.entry_id in hass.data[DOMAIN]
 
 
 async def test_unload_entry(hass: HomeAssistant, mock_config_entry, mock_librus_client):
     """Test unloading an entry."""
-    with patch(
-        "custom_components.librus_apix.LibrusApiClient",
-        return_value=mock_librus_client
-    ):
-        # Setup first
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        
-        # Then unload
-        result = await hass.config_entries.async_unload(mock_config_entry.entry_id)
-        assert result is True
+    await _setup(hass, mock_config_entry, mock_librus_client)
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.entry_id not in hass.data[DOMAIN]
+
+
+async def test_plan_lekcji_sensor(hass: HomeAssistant, mock_config_entry, mock_librus_client):
+    """Czujnik planu lekcji wystawia dzisiejsze lekcje i wykryte zmiany."""
+    await _setup(hass, mock_config_entry, mock_librus_client)
+
+    stan = hass.states.get("sensor.librus_jan_kowalski_plan_lekcji")
+    assert stan is not None
+    assert stan.state == "2"
+    assert stan.attributes["pierwsza_lekcja"] == "08:00"
+    assert stan.attributes["ostatnia_lekcja"] == "09:45"
+    assert [l["przedmiot"] for l in stan.attributes["jutro"]] == ["Historia"]
+    assert stan.attributes["sa_zmiany"] is True
+    assert [l["przedmiot"] for l in stan.attributes["zmiany"]] == ["Fizyka"]
+
+
+async def test_nastepna_lekcja_sensor(hass: HomeAssistant, mock_config_entry, mock_librus_client):
+    """Czujnik nastepnej lekcji wybiera pierwsza lekcje, ktora sie nie skonczyla."""
+    mock_librus_client.async_get_timetable.return_value = [
+        _lekcja(1, "Matematyka", "00:00", "00:01"),
+        _lekcja(2, "Fizyka", "23:58", "23:59"),
+    ]
+
+    await _setup(hass, mock_config_entry, mock_librus_client)
+
+    stan = hass.states.get("sensor.librus_jan_kowalski_nastepna_lekcja")
+    assert stan is not None
+    assert stan.state == "Fizyka"
+    assert stan.attributes["numer"] == 2
+    assert stan.attributes["od"] == "23:58"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,25 @@
 """Test the Librus APIX integration."""
 
-from datetime import date, timedelta
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.librus_apix.const import DOMAIN
+
+
+def _dzis():
+    """Dzisiejsza data wedlug strefy Home Assistanta.
+
+    Czujniki uzywaja dt_util.now(), a nie zegara systemowego. W testach HA
+    stoi na UTC, wiec date.today() rozjezdzalo sie o jeden dzien w oknie
+    00:00-02:00 czasu lokalnego (i zaleznie od strefy runnera w CI).
+    """
+    return dt_util.now().date()
 
 
 @pytest.fixture(autouse=True)
@@ -19,7 +30,7 @@ def auto_enable_custom_integrations(enable_custom_integrations):
 
 def _lekcja(numer, przedmiot, od, do, dzien=None, zastepstwo=False, odwolana=False):
     """Zbuduj wpis planu lekcji w formacie zwracanym przez async_get_timetable."""
-    dzien = dzien or date.today()
+    dzien = dzien or _dzis()
     return {
         "data": dzien.strftime("%Y-%m-%d"),
         "dzien_tygodnia": "Poniedziałek",
@@ -79,7 +90,7 @@ def mock_librus_client():
     client.async_get_timetable = AsyncMock(return_value=[
         _lekcja(1, "Matematyka", "08:00", "08:45"),
         _lekcja(2, "Fizyka", "09:00", "09:45", zastepstwo=True),
-        _lekcja(1, "Historia", "08:00", "08:45", dzien=date.today() + timedelta(days=1)),
+        _lekcja(1, "Historia", "08:00", "08:45", dzien=_dzis() + timedelta(days=1)),
     ])
     return client
 
@@ -116,7 +127,7 @@ async def test_plan_lekcji_sensor(hass: HomeAssistant, mock_config_entry, mock_l
     mock_librus_client.async_get_timetable.return_value = [
         _lekcja(1, "Matematyka", "00:00", "00:45"),
         _lekcja(2, "Fizyka", "23:10", "23:59", zastepstwo=True),
-        _lekcja(1, "Historia", "08:00", "08:45", dzien=date.today() + timedelta(days=1)),
+        _lekcja(1, "Historia", "08:00", "08:45", dzien=_dzis() + timedelta(days=1)),
     ]
 
     await _setup(hass, mock_config_entry, mock_librus_client)
@@ -126,7 +137,7 @@ async def test_plan_lekcji_sensor(hass: HomeAssistant, mock_config_entry, mock_l
     assert stan.state == "2"
     assert stan.attributes["pierwsza_lekcja"] == "00:00"
     assert stan.attributes["ostatnia_lekcja"] == "23:59"
-    jutro = (date.today() + timedelta(days=1)).strftime("%Y-%m-%d")
+    jutro = (_dzis() + timedelta(days=1)).strftime("%Y-%m-%d")
     assert [l["przedmiot"] for l in stan.attributes["tydzien"][jutro]] == ["Historia"]
     assert stan.attributes["sa_zmiany"] is True
     assert [l["przedmiot"] for l in stan.attributes["zmiany"]] == ["Fizyka"]
@@ -152,7 +163,7 @@ async def test_plan_lekcji_przeskakuje_na_kolejny_dzien(
     hass: HomeAssistant, mock_config_entry, mock_librus_client
 ):
     """Po ostatniej lekcji dnia czujnik pokazuje plan nastepnego dnia."""
-    jutro = date.today() + timedelta(days=1)
+    jutro = _dzis() + timedelta(days=1)
     mock_librus_client.async_get_timetable.return_value = [
         # Dzisiejsze lekcje sa juz po czasie (koncza sie o 00:01).
         _lekcja(1, "Matematyka", "00:00", "00:01"),
@@ -183,21 +194,21 @@ async def test_plan_lekcji_trzyma_sie_dzis_w_trakcie_zajec(
     """Dopoki trwa ostatnia lekcja, pokazywany jest biezacy dzien."""
     mock_librus_client.async_get_timetable.return_value = [
         _lekcja(1, "Matematyka", "00:00", "23:59"),
-        _lekcja(1, "Historia", "08:00", "08:45", dzien=date.today() + timedelta(days=1)),
+        _lekcja(1, "Historia", "08:00", "08:45", dzien=_dzis() + timedelta(days=1)),
     ]
 
     await _setup(hass, mock_config_entry, mock_librus_client)
 
     stan = hass.states.get("sensor.librus_jan_kowalski_plan_lekcji")
     assert [l["przedmiot"] for l in stan.attributes["tydzien"][stan.attributes["biezacy_dzien_data"]]] == ["Matematyka"]
-    assert stan.attributes["biezacy_dzien_data"] == date.today().strftime("%Y-%m-%d")
+    assert stan.attributes["biezacy_dzien_data"] == _dzis().strftime("%Y-%m-%d")
 
 
 async def test_plan_lekcji_zaznacza_wydarzenia_i_zadania(
     hass: HomeAssistant, mock_config_entry, mock_librus_client
 ):
     """Kartkowka trafia na swoja lekcje, wywiadowka do wydarzen calodniowych."""
-    dzis = date.today().strftime("%Y-%m-%d")
+    dzis = _dzis().strftime("%Y-%m-%d")
     mock_librus_client.async_get_timetable.return_value = [
         _lekcja(1, "matematyka", "00:00", "00:45"),
         _lekcja(4, "fizyka", "23:10", "23:59"),
@@ -240,7 +251,7 @@ async def test_plan_tygodnia_zawsze_pokazuje_piec_dni(
     hass: HomeAssistant, mock_config_entry, mock_librus_client
 ):
     """Po ostatniej lekcji dnia w planie nadal jest piec dni lekcyjnych."""
-    dzis = date.today()
+    dzis = _dzis()
     # Dzisiejsze lekcje juz sie skonczyly, kolejne szesc dni ma zajecia.
     plan = [_lekcja(1, "matematyka", "00:00", "00:01")]
     for i in range(1, 7):

--- a/tests/test_plan_lekcji.py
+++ b/tests/test_plan_lekcji.py
@@ -328,3 +328,45 @@ def test_polaczenie_bez_danych_nie_psuje_planu():
     assert len(plan) == 3
     assert all(l["wydarzenia"] == [] and l["zadania"] == [] for l in plan)
     assert dnia == {} and zadania_dnia == {}
+
+
+def test_dni_do_wyswietlenia_ogranicza_liczbe_dni():
+    plan = przetworz_plan(
+        [
+            tydzien(
+                *[
+                    period(date_=f"2026-09-{7 + i:02d}", number=1, date_from="08:00",
+                           date_to="08:45", weekday="Monday")
+                    for i in range(6)
+                ]
+            )
+        ]
+    )
+
+    dni = dni_do_wyswietlenia(plan, datetime(2026, 9, 7, 7, 0), 5)
+
+    assert len(dni) == 5
+    assert list(dni)[0] == "2026-09-07"
+    assert list(dni)[-1] == "2026-09-11"
+
+
+def test_limit_liczony_po_odfiltrowaniu_zakonczonych_dni():
+    """Zakonczony dzien nie zajmuje miejsca w limicie."""
+    plan = przetworz_plan(
+        [
+            tydzien(
+                *[
+                    period(date_=f"2026-09-{7 + i:02d}", number=1, date_from="08:00",
+                           date_to="08:45", weekday="Monday")
+                    for i in range(6)
+                ]
+            )
+        ]
+    )
+
+    # Po ostatniej lekcji 07.09 pierwszy dzien wypada, wiec dochodzi 12.09.
+    dni = dni_do_wyswietlenia(plan, datetime(2026, 9, 7, 9, 0), 5)
+
+    assert len(dni) == 5
+    assert list(dni)[0] == "2026-09-08"
+    assert list(dni)[-1] == "2026-09-12"

--- a/tests/test_plan_lekcji.py
+++ b/tests/test_plan_lekcji.py
@@ -1,0 +1,166 @@
+"""Testy czystej logiki planu lekcji."""
+
+from datetime import date, datetime
+from types import SimpleNamespace
+
+from custom_components.librus_apix.plan_lekcji import (
+    lekcje_dnia,
+    nastepna_lekcja,
+    pogrupuj_wg_dni,
+    przetworz_plan,
+)
+
+
+def period(
+    subject="Matematyka",
+    date_="2026-09-07",
+    number=1,
+    date_from="08:00",
+    date_to="08:45",
+    weekday="Monday",
+    info=None,
+    teacher_and_classroom=" 12",
+    next_recess_from=None,
+    next_recess_to=None,
+):
+    """Zbuduj atrape obiektu Period z librus_apix."""
+    return SimpleNamespace(
+        subject=subject,
+        teacher_and_classroom=teacher_and_classroom,
+        date=date_,
+        date_from=date_from,
+        date_to=date_to,
+        weekday=weekday,
+        info=info or {},
+        number=number,
+        next_recess_from=next_recess_from,
+        next_recess_to=next_recess_to,
+    )
+
+
+def tydzien(*periods):
+    """Owin okresy w strukture tygodnia (lista dni, kazdy dzien to lista okresow)."""
+    return [list(periods)]
+
+
+def test_przetworz_plan_pomija_puste_okienka():
+    plan = przetworz_plan([tydzien(period(subject=""), period(subject="  "), period())])
+
+    assert len(plan) == 1
+    assert plan[0]["przedmiot"] == "Matematyka"
+
+
+def test_przetworz_plan_tlumaczy_dzien_i_sortuje():
+    plan = przetworz_plan(
+        [
+            tydzien(
+                period(date_="2026-09-08", number=2, weekday="Tuesday"),
+                period(date_="2026-09-07", number=3, weekday="Monday"),
+                period(date_="2026-09-07", number=1, weekday="Monday"),
+            )
+        ]
+    )
+
+    assert [(l["data"], l["numer"]) for l in plan] == [
+        ("2026-09-07", 1),
+        ("2026-09-07", 3),
+        ("2026-09-08", 2),
+    ]
+    assert plan[0]["dzien_tygodnia"] == "Poniedzialek"
+    assert plan[-1]["dzien_tygodnia"] == "Wtorek"
+
+
+def test_przetworz_plan_wykrywa_zastepstwo_i_odwolanie():
+    plan = przetworz_plan(
+        [
+            tydzien(
+                period(number=1, info={"Zastępstwo": {"teacher_swap": "Nowak"}}),
+                period(number=2, info={"Lekcja odwołana": ""}),
+                period(number=3),
+            )
+        ]
+    )
+
+    zastepstwo, odwolana, zwykla = plan
+    assert zastepstwo["zastepstwo"] is True and zastepstwo["odwolana"] is False
+    assert odwolana["odwolana"] is True and odwolana["zastepstwo"] is False
+    assert zwykla["zastepstwo"] is False and zwykla["odwolana"] is False
+    assert zwykla["info"] == ""
+
+
+def test_przetworz_plan_deduplikuje_powtorzone_tygodnie():
+    plan = przetworz_plan([tydzien(period()), tydzien(period())])
+
+    assert len(plan) == 1
+
+
+def test_nastepna_lekcja_zwraca_najblizsza_przyszla():
+    plan = przetworz_plan(
+        [
+            tydzien(
+                period(number=1, date_from="08:00", date_to="08:45"),
+                period(number=2, date_from="09:00", date_to="09:45", subject="Fizyka"),
+            )
+        ]
+    )
+
+    wynik = nastepna_lekcja(plan, datetime(2026, 9, 7, 8, 50))
+
+    assert wynik["przedmiot"] == "Fizyka"
+    assert wynik["trwa_teraz"] is False
+    assert wynik["za_minut"] == 10
+
+
+def test_nastepna_lekcja_zwraca_trwajaca():
+    plan = przetworz_plan([tydzien(period(date_from="08:00", date_to="08:45"))])
+
+    wynik = nastepna_lekcja(plan, datetime(2026, 9, 7, 8, 30))
+
+    assert wynik["trwa_teraz"] is True
+    assert wynik["za_minut"] == 0
+
+
+def test_nastepna_lekcja_pomija_odwolane():
+    plan = przetworz_plan(
+        [
+            tydzien(
+                period(number=1, date_from="08:00", info={"Lekcja odwołana": ""}),
+                period(number=2, date_from="09:00", date_to="09:45", subject="Fizyka"),
+            )
+        ]
+    )
+
+    wynik = nastepna_lekcja(plan, datetime(2026, 9, 7, 7, 0))
+
+    assert wynik["przedmiot"] == "Fizyka"
+
+
+def test_nastepna_lekcja_brak_gdy_wszystko_minelo():
+    plan = przetworz_plan([tydzien(period(date_from="08:00", date_to="08:45"))])
+
+    assert nastepna_lekcja(plan, datetime(2026, 9, 7, 9, 0)) is None
+
+
+def test_nastepna_lekcja_ignoruje_bledne_godziny():
+    plan = przetworz_plan([tydzien(period(date_from="", date_to=""))])
+
+    assert nastepna_lekcja(plan, datetime(2026, 9, 7, 7, 0)) is None
+
+
+def test_lekcje_dnia_i_grupowanie():
+    plan = przetworz_plan(
+        [
+            tydzien(
+                period(date_="2026-09-07", number=1),
+                period(date_="2026-09-07", number=2),
+                period(date_="2026-09-08", number=1, weekday="Tuesday"),
+            )
+        ]
+    )
+
+    assert len(lekcje_dnia(plan, date(2026, 9, 7))) == 2
+    assert lekcje_dnia(plan, date(2026, 9, 9)) == []
+
+    dni = pogrupuj_wg_dni(plan)
+    assert list(dni.keys()) == ["2026-09-07", "2026-09-08"]
+    assert len(dni["2026-09-07"]) == 2

--- a/tests/test_plan_lekcji.py
+++ b/tests/test_plan_lekcji.py
@@ -69,7 +69,7 @@ def test_przetworz_plan_tlumaczy_dzien_i_sortuje():
         ("2026-09-07", 3),
         ("2026-09-08", 2),
     ]
-    assert plan[0]["dzien_tygodnia"] == "Poniedzialek"
+    assert plan[0]["dzien_tygodnia"] == "Poniedziałek"
     assert plan[-1]["dzien_tygodnia"] == "Wtorek"
 
 

--- a/tests/test_plan_lekcji.py
+++ b/tests/test_plan_lekcji.py
@@ -4,8 +4,11 @@ from datetime import date, datetime
 from types import SimpleNamespace
 
 from custom_components.librus_apix.plan_lekcji import (
+    biezacy_dzien,
+    dni_do_wyswietlenia,
     lekcje_dnia,
     nastepna_lekcja,
+    polacz_z_wydarzeniami,
     pogrupuj_wg_dni,
     przetworz_plan,
 )
@@ -164,3 +167,164 @@ def test_lekcje_dnia_i_grupowanie():
     dni = pogrupuj_wg_dni(plan)
     assert list(dni.keys()) == ["2026-09-07", "2026-09-08"]
     assert len(dni["2026-09-07"]) == 2
+
+
+def _dwa_dni():
+    """Plan na dzis (2 lekcje) i jutro (1 lekcja)."""
+    return przetworz_plan(
+        [
+            tydzien(
+                period(number=1, date_from="08:00", date_to="08:45"),
+                period(number=2, date_from="09:00", date_to="09:45", subject="Fizyka"),
+                period(
+                    number=1, date_="2026-09-08", weekday="Tuesday",
+                    date_from="08:00", date_to="08:45", subject="Historia",
+                ),
+            )
+        ]
+    )
+
+
+def test_biezacy_dzien_pokazuje_dzis_w_trakcie_zajec():
+    wynik = biezacy_dzien(_dwa_dni(), datetime(2026, 9, 7, 8, 30))
+
+    assert [l["data"] for l in wynik] == ["2026-09-07"] * 2
+
+
+def test_biezacy_dzien_pokazuje_dzis_az_do_konca_ostatniej_lekcji():
+    # Minuta przed koncem ostatniej lekcji dzien nadal jest aktualny.
+    wynik = biezacy_dzien(_dwa_dni(), datetime(2026, 9, 7, 9, 44))
+
+    assert wynik[0]["data"] == "2026-09-07"
+
+
+def test_biezacy_dzien_przechodzi_na_kolejny_po_ostatniej_lekcji():
+    wynik = biezacy_dzien(_dwa_dni(), datetime(2026, 9, 7, 9, 46))
+
+    assert [l["przedmiot"] for l in wynik] == ["Historia"]
+    assert wynik[0]["data"] == "2026-09-08"
+
+
+def test_biezacy_dzien_pusty_gdy_caly_plan_minal():
+    assert biezacy_dzien(_dwa_dni(), datetime(2026, 9, 9, 0, 0)) == []
+
+
+def test_dni_do_wyswietlenia_pomija_zakonczone():
+    dni = dni_do_wyswietlenia(_dwa_dni(), datetime(2026, 9, 7, 9, 46))
+
+    assert list(dni.keys()) == ["2026-09-08"]
+
+
+def test_dni_do_wyswietlenia_zachowuje_dzien_bez_godzin():
+    # Nie ukrywamy danych, ktorych nie da sie zinterpretowac.
+    plan = przetworz_plan([tydzien(period(date_from="", date_to=""))])
+
+    assert list(dni_do_wyswietlenia(plan, datetime(2026, 9, 9, 0, 0))) == ["2026-09-07"]
+
+
+def _plan_dnia():
+    """Trzy lekcje jednego dnia: fizyka jest lekcja nr 4."""
+    return przetworz_plan(
+        [
+            tydzien(
+                period(number=3, subject="matematyka"),
+                period(number=4, subject="fizyka"),
+                period(number=5, subject="historia"),
+            )
+        ]
+    )
+
+
+def _zdarzenie(**kw):
+    baza = {
+        "data": "2026-09-07",
+        "tytul": "kartkówka",
+        "przedmiot": "fizyka",
+        "godzina": "unknown",
+        "numer_lekcji": 4,
+        "szczegoly": {"Nauczyciel": "Anna Nowak", "Opis": "wielkości fizyczne"},
+    }
+    baza.update(kw)
+    return baza
+
+
+def test_wydarzenie_przypina_sie_po_numerze_lekcji():
+    plan, dnia, _ = polacz_z_wydarzeniami(_plan_dnia(), [_zdarzenie()])
+
+    fizyka = next(l for l in plan if l["numer"] == 4)
+    assert [w["tytul"] for w in fizyka["wydarzenia"]] == ["kartkówka"]
+    assert fizyka["wydarzenia"][0]["opis"] == "wielkości fizyczne"
+    assert dnia == {}
+    # pozostale lekcje nietkniete
+    assert all(not l["wydarzenia"] for l in plan if l["numer"] != 4)
+
+
+def test_wydarzenie_przypina_sie_po_przedmiocie_gdy_brak_numeru():
+    # Librus zwraca "unknown" zamiast numeru lekcji.
+    plan, dnia, _ = polacz_z_wydarzeniami(
+        _plan_dnia(), [_zdarzenie(numer_lekcji="unknown", przedmiot="Historia")]
+    )
+
+    historia = next(l for l in plan if l["numer"] == 5)
+    assert len(historia["wydarzenia"]) == 1
+    assert dnia == {}
+
+
+def test_wydarzenie_bez_dopasowania_trafia_do_calodniowych():
+    zdarzenie = _zdarzenie(
+        numer_lekcji="unknown",
+        tytul="godz.: 17:00",
+        przedmiot="Wywiadówka: zebranie rodziców",
+    )
+
+    plan, dnia, _ = polacz_z_wydarzeniami(_plan_dnia(), [zdarzenie])
+
+    assert all(not l["wydarzenia"] for l in plan)
+    assert [w["przedmiot"] for w in dnia["2026-09-07"]] == ["Wywiadówka: zebranie rodziców"]
+
+
+def test_wydarzenie_z_innego_dnia_jest_pomijane():
+    plan, dnia, _ = polacz_z_wydarzeniami(_plan_dnia(), [_zdarzenie(data="2026-10-01")])
+
+    assert all(not l["wydarzenia"] for l in plan)
+    assert dnia == {}
+
+
+def test_zadanie_przypina_sie_do_dnia_terminu():
+    zadanie = {
+        "przedmiot": "Matematyka",
+        "kategoria": "Praca domowa",
+        "termin": "2026-09-07",
+        "nauczyciel": "Danuta Kowalska",
+    }
+
+    plan, _, zadania_dnia = polacz_z_wydarzeniami(_plan_dnia(), None, [zadanie])
+
+    matematyka = next(l for l in plan if l["numer"] == 3)
+    assert [z["kategoria"] for z in matematyka["zadania"]] == ["Praca domowa"]
+    assert zadania_dnia == {}
+
+
+def test_zadanie_toleruje_date_z_kropkami():
+    zadanie = {"przedmiot": "fizyka", "kategoria": "Zadanie", "termin": "07.09.2026"}
+
+    plan, _, _ = polacz_z_wydarzeniami(_plan_dnia(), None, [zadanie])
+
+    assert len(next(l for l in plan if l["numer"] == 4)["zadania"]) == 1
+
+
+def test_zadanie_bez_lekcji_z_przedmiotu_trafia_do_calodniowych():
+    zadanie = {"przedmiot": "geografia", "kategoria": "Projekt", "termin": "2026-09-07"}
+
+    plan, _, zadania_dnia = polacz_z_wydarzeniami(_plan_dnia(), None, [zadanie])
+
+    assert all(not l["zadania"] for l in plan)
+    assert [z["przedmiot"] for z in zadania_dnia["2026-09-07"]] == ["geografia"]
+
+
+def test_polaczenie_bez_danych_nie_psuje_planu():
+    plan, dnia, zadania_dnia = polacz_z_wydarzeniami(_plan_dnia(), None, None)
+
+    assert len(plan) == 3
+    assert all(l["wydarzenia"] == [] and l["zadania"] == [] for l in plan)
+    assert dnia == {} and zadania_dnia == {}


### PR DESCRIPTION
Dodaje obsługę **planu lekcji** wraz z oznaczaniem wydarzeń z terminarza i prac
domowych na kartach. Przy okazji naprawia kilka rzeczy, które są w repozytorium
niezależnie od tej funkcjonalności — opisane niżej w osobnej sekcji.

Wszystko sprawdzone na działającym Home Assistant 2026.9 z prawdziwym kontem
Librus Synergia, nie tylko na atrapach.

## Nowe encje

| Encja | Stan | Opis |
|---|---|---|
| `sensor.librus_<uczen>_plan_lekcji` | liczba lekcji dzisiaj | plan na najbliższe 5 dni lekcyjnych |
| `sensor.librus_<uczen>_nastepna_lekcja` | nazwa przedmiotu | trwająca lub najbliższa lekcja |

Plan pobierany jest dla bieżącego i następnego tygodnia, więc w piątek po
południu i w weekend widać już kolejny tydzień.

**Dzień znika, gdy skończy się jego ostatnia lekcja** — karta przechodzi wtedy
na najbliższy kolejny dzień z zajęciami, a plan tygodnia dobiera dzień w jego
miejsce, żeby zawsze było widać 5 dni lekcyjnych (stała `DEFAULT_PLAN_DAYS`).

Oba czujniki przeliczają się **co minutę lokalnie**, bez odpytywania Librusa.
Dzięki temu odliczanie „za X minut" i przeskok dnia działają na bieżąco mimo
dwugodzinnego interwału koordynatora.

## Zastępstwa, wydarzenia i prace domowe

- Zastępstwa i odwołane lekcje są wykrywane i oznaczane; nowe zmiany wysyłają
  zdarzenie `librus_apix_zmiana_planu` (przykładowa automatyzacja w README).
- Wydarzenia z terminarza są przypinane do konkretnej lekcji — najpierw po
  numerze lekcji, a gdy Librus zwróci `"unknown"`, po nazwie przedmiotu.
  Czego nie da się przypiąć (wywiadówka, dzień wolny), trafia do wydarzeń
  całodniowych nad tabelą dnia.
- Prace domowe są przypinane do dnia, w którym mija termin oddania.

## Karty Lovelace

Gotowy dashboard do wklejenia: `examples/dashboard-plan-lekcji.yaml`
(placeholder `sensor.librus_imie_nazwisko_*` do podmiany). W README instrukcja
krok po kroku.

Doszła też karta **nadchodzących wydarzeń** na 4 tygodnie. To maksimum, jakie
obecny `async_get_schedule` gwarantuje: pobiera bieżący i następny miesiąc, więc
najkrótszy możliwy horyzont wypada 31 stycznia i wynosi dokładnie 28 dni.
Dłuższy okres urywałby się po cichu na końcu miesiąca — zapisane w README.

Sprawdziany i kartkówki są w tabelach czerwone i pogrubione, prace domowe żółte.
Tła całego wiersza **nie da się** ustawić: karta markdown przepuszcza treść przez
bibliotekę `xss`, która usuwa `style`, `class` i `bgcolor` ze znaczników `<tr>`
i `<td>`. Na białej liście jest `<font color>`, więc kolorowany jest tekst
wszystkich czterech komórek. Zweryfikowane przez odtworzenie `markdown-worker.ts`
z frontendu HA w Node i przepuszczenie przez niego realnego wyniku.

## Częstotliwość odświeżania w UI

**Ustawienia → Urządzenia i usługi → Librus APIX → Konfiguruj**, domyślnie
120 minut, zakres 15–1440. Użyty `OptionsFlowWithReload`, więc zmiana działa
od razu bez restartu HA.

W opisie opcji podany koszt, żeby wybór był świadomy: jedno odświeżenie to
8 zapytań HTTP, czyli ok. 96 na dobę przy 120 minutach i ponad 750 przy 15.

## Naprawy istniejących problemów

Te trzy dotyczą repozytorium niezależnie od nowej funkcjonalności:

1. **Żaden test nigdy się nie uruchamiał.** Brakowało konfiguracji pytest,
   a `pytest-homeassistant-custom-component` wymaga `asyncio_mode = auto`.
   Do tego `tests/test_init.py` używał nieaktualnej sygnatury `ConfigEntry`
   (`TypeError: missing 5 required keyword-only arguments`). Dodany `pytest.ini`,
   testy przepisane na `MockConfigEntry`.
2. **Środowisko testowe z `docker-compose` nie startowało.** `configuration.yaml`
   robi `!include_dir_merge_named themes`, a katalogu `config/themes/` nie było.
   Dodatkowo `sensor: - platform: template` jest odrzucane przez aktualne HA
   („must be configured under its own template key instead") — zmigrowane.
   Doszło też `time_zone: Europe/Warsaw`, bo bez tego HA startuje w UTC
   i szablony z `now()` pokazują godziny przesunięte.
3. **Terminarz zwracał angielskie nazwy dni** (`Tuesday`, `Wednesday`)
   w polskiej integracji, a karta terminarza w README je wyświetlała.

## Zmiana zachowania — do świadomej akceptacji

Pole `tydzien` w atrybucie `zdarzenia` sensora terminarza zwraca teraz **polskie**
nazwy dni zamiast angielskich. Karty korzystające z `{{ z.tydzien }}` zaczną
pokazywać „Wtorek" zamiast „Tuesday". Nic się nie psuje, ale to widoczna zmiana
dla obecnych użytkowników. Jeśli wolisz zachować zgodność wstecz, mogę dodać
osobne pole zamiast podmieniać istniejące.

Poza tym zmiany są addytywne: istniejące encje działają bez zmian, domyślny
interwał pozostaje 2 godziny.

## Testy

39 testów, w tym czysta logika planu bez zależności od Home Assistanta
(`plan_lekcji.py` nie importuje HA, więc da się ją testować samodzielnie).

Zestaw przechodzi w `UTC`, `Europe/Warsaw`, `Pacific/Auckland`,
`America/Los_Angeles` i `Asia/Tokyo` — testy liczą „dziś" z `dt_util.now()`,
tak samo jak czujniki, więc nie rozjeżdżają się ze strefą runnera w CI.

## Uwagi

- Wersja w `manifest.json` podbita do `1.2.0`; jeśli wolisz inne numerowanie,
  chętnie poprawię.
- `librus-apix` przeniósł się z `RustySnek` na `poroknights` — adres w README
  zaktualizowany.
- README odsyłał do nieistniejącego `CONTRIBUTING.md`.
- Dodana tabela komponentów zewnętrznych z licencjami, z zaznaczeniem, że żaden
  nie jest dystrybuowany razem z repozytorium.
